### PR TITLE
hyprland: migrate home-manager config to Lua API

### DIFF
--- a/modules/omarchy/home-manager/hyprland/autostart.nix
+++ b/modules/omarchy/home-manager/hyprland/autostart.nix
@@ -1,11 +1,6 @@
 {...}: {
-  wayland.windowManager.hyprland.settings = {
-    exec-once = [
-      # "dropbox-cli start"  # Uncomment to run Dropbox
-    ];
-
-    exec = [
-      # "pkill -SIGUSR2 waybar || waybar"
-    ];
-  };
+  # Add startup commands by appending entries that produce
+  # `hl.on("hyprland.start", function() hl.exec_cmd("...") end)`.
+  # See https://wiki.hypr.land/Configuring/Basics/Autostart for examples.
+  wayland.windowManager.hyprland.settings = {};
 }

--- a/modules/omarchy/home-manager/hyprland/bindings.nix
+++ b/modules/omarchy/home-manager/hyprland/bindings.nix
@@ -1,104 +1,108 @@
 {lib, ...}: let
-  appLauncherBindings = [
-    "ALT, C, exec, $calendar"
-    "ALT, R, exec, $reminders"
-    "ALT, return, exec, $terminal"
-    "ALT, F, exec, $fileManager"
-    "ALT, B, exec, $browser"
-    "ALT, M, exec, $music"
-    "ALT, Z, exec, $editor"
-    "ALT, G, exec, $messenger"
-    "ALT, slash, exec, $passwordManager"
+  inline = lib.generators.mkLuaInline;
+  escape = lib.escape ["\\" "\""];
+
+  exec = cmd: inline ''hl.dsp.exec_cmd("${escape cmd}")'';
+  execLocal = name: inline "hl.dsp.exec_cmd(${name})";
+  dsp = expr: inline "hl.dsp.${expr}";
+
+  bind = keys: dispatcher: {_args = [keys dispatcher];};
+  bindFlags = keys: dispatcher: flags: {_args = [keys dispatcher flags];};
+
+  appLauncherBinds = [
+    (bind "ALT + C" (execLocal "calendar"))
+    (bind "ALT + R" (execLocal "reminders"))
+    (bind "ALT + return" (execLocal "terminal"))
+    (bind "ALT + F" (execLocal "fileManager"))
+    (bind "ALT + B" (execLocal "browser"))
+    (bind "ALT + M" (execLocal "music"))
+    (bind "ALT + Z" (execLocal "editor"))
+    (bind "ALT + G" (execLocal "messenger"))
+    (bind "ALT + slash" (execLocal "passwordManager"))
   ];
 
-  workspaceBindings = builtins.concatMap (n: [
-    "CTRL, ${toString n}, workspace, ${toString (
+  workspaceBinds = builtins.concatMap (n: let
+    ws = toString (
       if n == 0
       then 10
       else n
-    )}"
-    "CTRL SHIFT, ${toString n}, movetoworkspace, ${toString (
-      if n == 0
-      then 10
-      else n
-    )}"
+    );
+    key = toString n;
+  in [
+    (bind "CTRL + ${key}" (dsp ''focus({ workspace = ${ws} })''))
+    (bind "CTRL + SHIFT + ${key}" (dsp ''window.move({ workspace = ${ws} })''))
   ]) (builtins.genList (i: lib.mod (i + 1) 10) 10);
 in {
-  wayland.windowManager.hyprland.settings = {
-    bind =
-      appLauncherBindings
-      ++ workspaceBindings
-      ++ [
-        "SUPER, space, exec, wofi --show drun --sort-order=alphabetical"
-        "CTRL SHIFT, SPACE, exec, pkill -SIGUSR1 waybar"
+  wayland.windowManager.hyprland.settings.bind =
+    appLauncherBinds
+    ++ workspaceBinds
+    ++ [
+      (bind "SUPER + space" (exec "wofi --show drun --sort-order=alphabetical"))
+      (bind "CTRL + SHIFT + SPACE" (exec "pkill -SIGUSR1 waybar"))
 
-        "CTRL, Backspace, killactive,"
+      (bind "CTRL + Backspace" (dsp "window.close()"))
 
-        "CTRL, ESCAPE, exec, hyprlock"
-        "CTRL SHIFT, ESCAPE, exec, pkill -TERM steam; sleep 1; hyprexit"
-        "CTRL ALT, ESCAPE, exec, reboot"
-        "CTRL SHIFT ALT, ESCAPE, exec, systemctl poweroff"
+      (bind "CTRL + ESCAPE" (exec "hyprlock"))
+      (bind "CTRL + SHIFT + ESCAPE" (exec "pkill -TERM steam; sleep 1; hyprexit"))
+      (bind "CTRL + ALT + ESCAPE" (exec "reboot"))
+      (bind "CTRL + SHIFT + ALT + ESCAPE" (exec "systemctl poweroff"))
 
-        "CTRL, J, layoutmsg, togglesplit"
+      (bind "CTRL + J" (dsp ''layout("togglesplit")''))
 
-        "CTRL, left, movefocus, l"
-        "CTRL, right, movefocus, r"
-        "CTRL, up, movefocus, u"
-        "CTRL, down, movefocus, d"
+      (bind "CTRL + left" (dsp ''focus({ direction = "left" })''))
+      (bind "CTRL + right" (dsp ''focus({ direction = "right" })''))
+      (bind "CTRL + up" (dsp ''focus({ direction = "up" })''))
+      (bind "CTRL + down" (dsp ''focus({ direction = "down" })''))
 
-        "CTRL, comma, workspace, -1"
-        "CTRL, period, workspace, +1"
+      (bind "CTRL + comma" (dsp ''focus({ workspace = "-1" })''))
+      (bind "CTRL + period" (dsp ''focus({ workspace = "+1" })''))
 
-        "CTRL SHIFT, left, swapwindow, l"
-        "CTRL SHIFT, right, swapwindow, r"
-        "CTRL SHIFT, up, swapwindow, u"
-        "CTRL SHIFT, down, swapwindow, d"
+      (bind "CTRL + SHIFT + left" (dsp ''window.swap({ direction = "left" })''))
+      (bind "CTRL + SHIFT + right" (dsp ''window.swap({ direction = "right" })''))
+      (bind "CTRL + SHIFT + up" (dsp ''window.swap({ direction = "up" })''))
+      (bind "CTRL + SHIFT + down" (dsp ''window.swap({ direction = "down" })''))
 
-        "CTRL, minus, resizeactive, -100 0"
-        "CTRL, equal, resizeactive, 100 0"
-        "CTRL SHIFT, minus, resizeactive, 0 -100"
-        "CTRL SHIFT, equal, resizeactive, 0 100"
+      (bind "CTRL + minus" (dsp ''window.resize({ x = -100, y = 0, relative = true })''))
+      (bind "CTRL + equal" (dsp ''window.resize({ x = 100, y = 0, relative = true })''))
+      (bind "CTRL + SHIFT + minus" (dsp ''window.resize({ x = 0, y = -100, relative = true })''))
+      (bind "CTRL + SHIFT + equal" (dsp ''window.resize({ x = 0, y = 100, relative = true })''))
 
-        "CTRL, mouse_down, workspace, e+1"
-        "CTRL, mouse_up, workspace, e-1"
+      (bind "CTRL + mouse_down" (dsp ''focus({ workspace = "e+1" })''))
+      (bind "CTRL + mouse_up" (dsp ''focus({ workspace = "e-1" })''))
 
-        "CTRL, F1, exec, ~/.local/share/omarchy/bin/apple-display-brightness -5000"
-        "CTRL, F2, exec, ~/.local/share/omarchy/bin/apple-display-brightness +5000"
-        "SHIFT CTRL, F2, exec, ~/.local/share/omarchy/bin/apple-display-brightness +60000"
+      (bind "CTRL + F1" (exec "~/.local/share/omarchy/bin/apple-display-brightness -5000"))
+      (bind "CTRL + F2" (exec "~/.local/share/omarchy/bin/apple-display-brightness +5000"))
+      (bind "SHIFT + CTRL + F2" (exec "~/.local/share/omarchy/bin/apple-display-brightness +60000"))
 
-        "CTRL, S, togglespecialworkspace, magic"
-        "CTRL SHIFT, S, movetoworkspace, special:magic"
+      (bind "CTRL + S" (dsp ''workspace.toggle_special("magic")''))
+      (bind "CTRL + SHIFT + S" (dsp ''window.move({ workspace = "special:magic" })''))
 
-        ", PRINT, exec, hyprshot -m region"
-        "SHIFT, PRINT, exec, hyprshot -m window"
-        "CTRL, PRINT, exec, hyprshot -m output"
+      (bind "PRINT" (exec "hyprshot -m region"))
+      (bind "SHIFT + PRINT" (exec "hyprshot -m window"))
+      (bind "CTRL + PRINT" (exec "hyprshot -m output"))
 
-        ", XF86Tools, exec, gpu-screen-recorder-gtk"
+      (bind "XF86Tools" (exec "gpu-screen-recorder-gtk"))
 
-        "ALT, PRINT, exec, hyprpicker -a"
+      (bind "ALT + PRINT" (exec "hyprpicker -a"))
 
-        "CTRL ALT, V, exec, ghostty --class clipse -e clipse"
-      ];
+      (bind "CTRL + ALT + V" (exec "ghostty --class clipse -e clipse"))
 
-    bindm = [
-      "ALT, mouse:272, movewindow"
-      "ALT, mouse:273, resizewindow"
+      # Mouse drag/resize (hyprlang bindm)
+      (bindFlags "ALT + mouse:272" (dsp "window.drag()") {mouse = true;})
+      (bindFlags "ALT + mouse:273" (dsp "window.resize()") {mouse = true;})
+
+      # Audio + brightness, repeat-on-hold + works while locked (hyprlang bindel)
+      (bindFlags "XF86AudioRaiseVolume" (exec "wpctl set-volume -l 1 @DEFAULT_AUDIO_SINK@ 5%+") {repeating = true; locked = true;})
+      (bindFlags "XF86AudioLowerVolume" (exec "wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-") {repeating = true; locked = true;})
+      (bindFlags "XF86AudioMute" (exec "wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle") {repeating = true; locked = true;})
+      (bindFlags "XF86AudioMicMute" (exec "wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle") {repeating = true; locked = true;})
+      (bindFlags "XF86MonBrightnessUp" (exec "brightnessctl -e4 -n2 set 5%+") {repeating = true; locked = true;})
+      (bindFlags "XF86MonBrightnessDown" (exec "brightnessctl -e4 -n2 set 5%-") {repeating = true; locked = true;})
+
+      # Media keys, works while locked (hyprlang bindl)
+      (bindFlags "XF86AudioNext" (exec "playerctl next") {locked = true;})
+      (bindFlags "XF86AudioPause" (exec "playerctl play-pause") {locked = true;})
+      (bindFlags "XF86AudioPlay" (exec "playerctl play-pause") {locked = true;})
+      (bindFlags "XF86AudioPrev" (exec "playerctl previous") {locked = true;})
     ];
-
-    bindel = [
-      ",XF86AudioRaiseVolume, exec, wpctl set-volume -l 1 @DEFAULT_AUDIO_SINK@ 5%+"
-      ",XF86AudioLowerVolume, exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%-"
-      ",XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle"
-      ",XF86AudioMicMute, exec, wpctl set-mute @DEFAULT_AUDIO_SOURCE@ toggle"
-      ",XF86MonBrightnessUp, exec, brightnessctl -e4 -n2 set 5%+"
-      ",XF86MonBrightnessDown, exec, brightnessctl -e4 -n2 set 5%-"
-    ];
-
-    bindl = [
-      ", XF86AudioNext, exec, playerctl next"
-      ", XF86AudioPause, exec, playerctl play-pause"
-      ", XF86AudioPlay, exec, playerctl play-pause"
-      ", XF86AudioPrev, exec, playerctl previous"
-    ];
-  };
 }

--- a/modules/omarchy/home-manager/hyprland/default.nix
+++ b/modules/omarchy/home-manager/hyprland/default.nix
@@ -22,9 +22,7 @@
   config = lib.mkIf config.omarchy.enable {
     wayland.windowManager.hyprland = {
       enable = true;
-      # TODO: migrate settings to the Lua API and drop this pin.
-      # https://github.com/jasonboukheir/dotfiles/issues/25
-      configType = "hyprlang";
+      configType = "lua";
     };
     services.hyprpolkitagent.enable = true;
   };

--- a/modules/omarchy/home-manager/hyprland/defaultApps.nix
+++ b/modules/omarchy/home-manager/hyprland/defaultApps.nix
@@ -63,16 +63,16 @@ in {
   };
   config = {
     wayland.windowManager.hyprland.settings = {
-      "$calendar" = cfg.defaultApps.calendar;
-      "$reminders" = cfg.defaultApps.reminders;
-      "$terminal" = cfg.defaultApps.terminal;
-      "$editor" = cfg.defaultApps.editor;
-      "$fileManager" = cfg.defaultApps.fileManager;
-      "$browser" = cfg.defaultApps.browser;
-      "$music" = cfg.defaultApps.music;
-      "$passwordManager" = cfg.defaultApps.passwordManager;
-      "$messenger" = cfg.defaultApps.messenger;
-      "$webapp" = cfg.defaultApps.webapp;
+      calendar = {_var = cfg.defaultApps.calendar;};
+      reminders = {_var = cfg.defaultApps.reminders;};
+      terminal = {_var = cfg.defaultApps.terminal;};
+      editor = {_var = cfg.defaultApps.editor;};
+      fileManager = {_var = cfg.defaultApps.fileManager;};
+      browser = {_var = cfg.defaultApps.browser;};
+      music = {_var = cfg.defaultApps.music;};
+      passwordManager = {_var = cfg.defaultApps.passwordManager;};
+      messenger = {_var = cfg.defaultApps.messenger;};
+      webapp = {_var = cfg.defaultApps.webapp;};
     };
   };
 }

--- a/modules/omarchy/home-manager/hyprland/envs.nix
+++ b/modules/omarchy/home-manager/hyprland/envs.nix
@@ -1,36 +1,38 @@
 {
   config,
-  lib,
   ...
 }: let
   cursorSize = toString config.stylix.cursor.size;
+  envPair = name: value: {_args = [name value];};
 in {
   wayland.windowManager.hyprland.settings = {
     env = [
-      "XCURSOR_SIZE,${cursorSize}"
-      "HYPRCURSOR_SIZE,${cursorSize}"
+      (envPair "XCURSOR_SIZE" cursorSize)
+      (envPair "HYPRCURSOR_SIZE" cursorSize)
 
-      "GDK_BACKEND,wayland"
-      "QT_QPA_PLATFORM,wayland"
-      "QT_STYLE_OVERRIDE,kvantum"
-      "SDL_VIDEODRIVER,wayland"
-      "MOZ_ENABLE_WAYLAND,1"
-      "ELECTRON_OZONE_PLATFORM_HINT,wayland"
-      "OZONE_PLATFORM,wayland"
+      (envPair "GDK_BACKEND" "wayland")
+      (envPair "QT_QPA_PLATFORM" "wayland")
+      (envPair "QT_STYLE_OVERRIDE" "kvantum")
+      (envPair "SDL_VIDEODRIVER" "wayland")
+      (envPair "MOZ_ENABLE_WAYLAND" "1")
+      (envPair "ELECTRON_OZONE_PLATFORM_HINT" "wayland")
+      (envPair "OZONE_PLATFORM" "wayland")
 
-      "XDG_DATA_DIRS,$XDG_DATA_DIRS:$HOME/.nix-profile/share:/nix/var/nix/profiles/default/share"
+      (envPair "XDG_DATA_DIRS" "$XDG_DATA_DIRS:$HOME/.nix-profile/share:/nix/var/nix/profiles/default/share")
 
-      "XCOMPOSEFILE,~/.XCompose"
-      "EDITOR,nvim"
+      (envPair "XCOMPOSEFILE" "~/.XCompose")
+      (envPair "EDITOR" "nvim")
     ];
 
-    xwayland = {
-      force_zero_scaling = true;
-    };
+    config = {
+      xwayland = {
+        force_zero_scaling = true;
+      };
 
-    # Don't show update on first launch
-    ecosystem = {
-      no_update_news = true;
+      # Don't show update on first launch
+      ecosystem = {
+        no_update_news = true;
+      };
     };
   };
 }

--- a/modules/omarchy/home-manager/hyprland/input.nix
+++ b/modules/omarchy/home-manager/hyprland/input.nix
@@ -1,26 +1,27 @@
 {lib, ...}: {
   wayland.windowManager.hyprland.settings = {
-    # Environment variables
-    # https://wiki.hyprland.org/Configuring/Variables/#input
-    input = lib.mkDefault {
-      kb_layout = "us";
-      # kb_variant =
-      # kb_model =
-      kb_options = "compose:caps";
-      # kb_rules =
+    # https://wiki.hypr.land/Configuring/Variables/#input
+    config = lib.mkDefault {
+      input = {
+        kb_layout = "us";
+        # kb_variant =
+        # kb_model =
+        kb_options = "compose:caps";
+        # kb_rules =
 
-      follow_mouse = 1;
+        follow_mouse = 1;
 
-      sensitivity = 0; # -1.0 - 1.0, 0 means no modification.
+        sensitivity = 0; # -1.0 - 1.0, 0 means no modification.
 
-      touchpad = {
-        natural_scroll = false;
+        touchpad = {
+          natural_scroll = false;
+        };
       };
-    };
 
-    # https://wiki.hyprland.org/Configuring/Variables/#gestures
-    # gestures = lib.mkDefault {
-    #   workspace_swipe = false;
-    # };
+      # https://wiki.hypr.land/Configuring/Variables/#gestures
+      # gestures = {
+      #   workspace_swipe = false;
+      # };
+    };
   };
 }

--- a/modules/omarchy/home-manager/hyprland/looknfeel.nix
+++ b/modules/omarchy/home-manager/hyprland/looknfeel.nix
@@ -60,20 +60,20 @@
     ];
 
     animation = [
-      {leaf = "global"; enabled = true; speed = 10; curve = "default";}
-      {leaf = "border"; enabled = true; speed = 5.39; curve = "easeOutQuint";}
-      {leaf = "windows"; enabled = true; speed = 4.79; curve = "easeOutQuint";}
-      {leaf = "windowsIn"; enabled = true; speed = 4.1; curve = "easeOutQuint"; style = "popin 87%";}
-      {leaf = "windowsOut"; enabled = true; speed = 1.49; curve = "linear"; style = "popin 87%";}
-      {leaf = "fadeIn"; enabled = true; speed = 1.73; curve = "almostLinear";}
-      {leaf = "fadeOut"; enabled = true; speed = 1.46; curve = "almostLinear";}
-      {leaf = "fade"; enabled = true; speed = 3.03; curve = "quick";}
-      {leaf = "layers"; enabled = true; speed = 3.81; curve = "easeOutQuint";}
-      {leaf = "layersIn"; enabled = true; speed = 4; curve = "easeOutQuint"; style = "fade";}
-      {leaf = "layersOut"; enabled = true; speed = 1.5; curve = "linear"; style = "fade";}
-      {leaf = "fadeLayersIn"; enabled = true; speed = 1.79; curve = "almostLinear";}
-      {leaf = "fadeLayersOut"; enabled = true; speed = 1.39; curve = "almostLinear";}
-      {leaf = "workspaces"; enabled = false; speed = 0; curve = "ease";}
+      {leaf = "global"; enabled = true; speed = 10; bezier = "default";}
+      {leaf = "border"; enabled = true; speed = 5.39; bezier = "easeOutQuint";}
+      {leaf = "windows"; enabled = true; speed = 4.79; bezier = "easeOutQuint";}
+      {leaf = "windowsIn"; enabled = true; speed = 4.1; bezier = "easeOutQuint"; style = "popin 87%";}
+      {leaf = "windowsOut"; enabled = true; speed = 1.49; bezier = "linear"; style = "popin 87%";}
+      {leaf = "fadeIn"; enabled = true; speed = 1.73; bezier = "almostLinear";}
+      {leaf = "fadeOut"; enabled = true; speed = 1.46; bezier = "almostLinear";}
+      {leaf = "fade"; enabled = true; speed = 3.03; bezier = "quick";}
+      {leaf = "layers"; enabled = true; speed = 3.81; bezier = "easeOutQuint";}
+      {leaf = "layersIn"; enabled = true; speed = 4; bezier = "easeOutQuint"; style = "fade";}
+      {leaf = "layersOut"; enabled = true; speed = 1.5; bezier = "linear"; style = "fade";}
+      {leaf = "fadeLayersIn"; enabled = true; speed = 1.79; bezier = "almostLinear";}
+      {leaf = "fadeLayersOut"; enabled = true; speed = 1.39; bezier = "almostLinear";}
+      {leaf = "workspaces"; enabled = false; speed = 0; bezier = "almostLinear";}
     ];
   };
 }

--- a/modules/omarchy/home-manager/hyprland/looknfeel.nix
+++ b/modules/omarchy/home-manager/hyprland/looknfeel.nix
@@ -1,77 +1,79 @@
 {...}: {
   wayland.windowManager.hyprland.settings = {
-    general = {
-      gaps_in = 5;
-      gaps_out = 10;
+    config = {
+      general = {
+        gaps_in = 5;
+        gaps_out = 10;
 
-      border_size = 2;
+        border_size = 2;
 
-      resize_on_border = false;
+        resize_on_border = false;
 
-      allow_tearing = false;
+        allow_tearing = false;
 
-      layout = "dwindle";
-    };
-
-    decoration = {
-      rounding = 4;
-
-      shadow = {
-        enabled = false;
-        range = 30;
-        render_power = 3;
+        layout = "dwindle";
       };
 
-      blur = {
-        enabled = true;
-        size = 5;
-        passes = 2;
+      decoration = {
+        rounding = 4;
 
-        vibrancy = 0.1696;
+        shadow = {
+          enabled = false;
+          range = 30;
+          render_power = 3;
+        };
+
+        blur = {
+          enabled = true;
+          size = 5;
+          passes = 2;
+
+          vibrancy = 0.1696;
+        };
+      };
+
+      animations = {
+        enabled = true; # yes, please :)
+      };
+
+      dwindle = {
+        preserve_split = true;
+        force_split = 2;
+      };
+
+      master = {
+        new_status = "master";
+      };
+
+      misc = {
+        disable_hyprland_logo = true;
+        disable_splash_rendering = true;
       };
     };
 
-    animations = {
-      enabled = true; # yes, please :)
+    curve = [
+      {_args = ["easeOutQuint" {type = "bezier"; points = [[0.23 1] [0.32 1]];}];}
+      {_args = ["easeInOutCubic" {type = "bezier"; points = [[0.65 0.05] [0.36 1]];}];}
+      {_args = ["linear" {type = "bezier"; points = [[0 0] [1 1]];}];}
+      {_args = ["almostLinear" {type = "bezier"; points = [[0.5 0.5] [0.75 1.0]];}];}
+      {_args = ["quick" {type = "bezier"; points = [[0.15 0] [0.1 1]];}];}
+    ];
 
-      bezier = [
-        "easeOutQuint,0.23,1,0.32,1"
-        "easeInOutCubic,0.65,0.05,0.36,1"
-        "linear,0,0,1,1"
-        "almostLinear,0.5,0.5,0.75,1.0"
-        "quick,0.15,0,0.1,1"
-      ];
-
-      animation = [
-        "global, 1, 10, default"
-        "border, 1, 5.39, easeOutQuint"
-        "windows, 1, 4.79, easeOutQuint"
-        "windowsIn, 1, 4.1, easeOutQuint, popin 87%"
-        "windowsOut, 1, 1.49, linear, popin 87%"
-        "fadeIn, 1, 1.73, almostLinear"
-        "fadeOut, 1, 1.46, almostLinear"
-        "fade, 1, 3.03, quick"
-        "layers, 1, 3.81, easeOutQuint"
-        "layersIn, 1, 4, easeOutQuint, fade"
-        "layersOut, 1, 1.5, linear, fade"
-        "fadeLayersIn, 1, 1.79, almostLinear"
-        "fadeLayersOut, 1, 1.39, almostLinear"
-        "workspaces, 0, 0, ease"
-      ];
-    };
-
-    dwindle = {
-      preserve_split = true;
-      force_split = 2;
-    };
-
-    master = {
-      new_status = "master";
-    };
-
-    misc = {
-      disable_hyprland_logo = true;
-      disable_splash_rendering = true;
-    };
+    animation = [
+      {leaf = "global"; enabled = true; speed = 10; curve = "default";}
+      {leaf = "border"; enabled = true; speed = 5.39; curve = "easeOutQuint";}
+      {leaf = "windows"; enabled = true; speed = 4.79; curve = "easeOutQuint";}
+      {leaf = "windowsIn"; enabled = true; speed = 4.1; curve = "easeOutQuint"; style = "popin 87%";}
+      {leaf = "windowsOut"; enabled = true; speed = 1.49; curve = "linear"; style = "popin 87%";}
+      {leaf = "fadeIn"; enabled = true; speed = 1.73; curve = "almostLinear";}
+      {leaf = "fadeOut"; enabled = true; speed = 1.46; curve = "almostLinear";}
+      {leaf = "fade"; enabled = true; speed = 3.03; curve = "quick";}
+      {leaf = "layers"; enabled = true; speed = 3.81; curve = "easeOutQuint";}
+      {leaf = "layersIn"; enabled = true; speed = 4; curve = "easeOutQuint"; style = "fade";}
+      {leaf = "layersOut"; enabled = true; speed = 1.5; curve = "linear"; style = "fade";}
+      {leaf = "fadeLayersIn"; enabled = true; speed = 1.79; curve = "almostLinear";}
+      {leaf = "fadeLayersOut"; enabled = true; speed = 1.39; curve = "almostLinear";}
+      {leaf = "workspaces"; enabled = false; speed = 0; curve = "ease";}
+    ];
   };
 }

--- a/modules/omarchy/home-manager/hyprland/monitor.nix
+++ b/modules/omarchy/home-manager/hyprland/monitor.nix
@@ -26,7 +26,7 @@
   // lib.optionalAttrs (hdrCfg.maxLuminance != null) {max_luminance = hdrCfg.maxLuminance;}
   // lib.optionalAttrs (hdrCfg.maxAvgLuminance != null) {max_avg_luminance = hdrCfg.maxAvgLuminance;});
 in {
-  wayland.windowManager.hyprland.settings.monitorv2 = [
+  wayland.windowManager.hyprland.settings.monitor = [
     (baseSettings // hdrSettings)
   ];
 }

--- a/modules/omarchy/home-manager/hyprland/windows.nix
+++ b/modules/omarchy/home-manager/hyprland/windows.nix
@@ -1,43 +1,53 @@
 {...}: {
   wayland.windowManager.hyprland.settings = {
-    windowrule = [
-      # See https://wiki.hyprland.org/Configuring/Window-Rules/ for more
-      "suppress_event maximize, match:class .*"
+    # See https://wiki.hypr.land/Configuring/Window-Rules for more
+    window_rule = [
+      {match = {class = ".*";}; suppress_event = "maximize";}
 
       # Force chromium into a tile to deal with --app bug
-      "tile on, match:class ^(chromium)$"
+      {match = {class = "^(chromium)$";}; tile = true;}
 
       # Settings management
-      "float on, match:class ^(org.pulseaudio.pavucontrol|blueberry.py)$"
+      {match = {class = "^(org.pulseaudio.pavucontrol|blueberry.py)$";}; float = true;}
 
       # Float Steam, fullscreen RetroArch
-      "float on, match:class ^(steam)$"
-      "center on, match:class ^(steam)$"
-      "fullscreen on, match:class ^(com.libretro.RetroArch)$"
+      {match = {class = "^(steam)$";}; float = true;}
+      {match = {class = "^(steam)$";}; center = true;}
+      {match = {class = "^(com.libretro.RetroArch)$";}; fullscreen = true;}
 
       # Just dash of transparency
-      "opacity 1 0.97, match:class .*"
+      {match = {class = ".*";}; opacity = "1 0.97";}
       # Normal chrome Youtube tabs
-      "opacity 1 1, match:class ^(chromium|google-chrome|google-chrome-unstable|helium)$, match:title .*[Yy]ou[Tt]ube.*"
-      "opacity 1 0.97, match:class ^(chromium|google-chrome|google-chrome-unstable)$"
-      "opacity 1 0.97, match:initial_class ^(chrome-.*-Default)$ # web apps"
-      "opacity 1 1, match:initial_class ^(chrome-[Yy]ou[Tt]ube.*-Default)$ # Youtube"
-      "opacity 1 1, match:class ^(zoom|vlc|org.kde.kdenlive|com.obsproject.Studio)$"
-      "opacity 1 1, match:class ^(com.libretro.RetroArch|steam)$"
+      {match = {class = "^(chromium|google-chrome|google-chrome-unstable|helium)$"; title = ".*[Yy]ou[Tt]ube.*";}; opacity = "1 1";}
+      {match = {class = "^(chromium|google-chrome|google-chrome-unstable)$";}; opacity = "1 0.97";}
+      {match = {initial_class = "^(chrome-.*-Default)$";}; opacity = "1 0.97";} # web apps
+      {match = {initial_class = "^(chrome-[Yy]ou[Tt]ube.*-Default)$";}; opacity = "1 1";} # YouTube
+      {match = {class = "^(zoom|vlc|org.kde.kdenlive|com.obsproject.Studio)$";}; opacity = "1 1";}
+      {match = {class = "^(com.libretro.RetroArch|steam)$";}; opacity = "1 1";}
 
       # Fix some dragging issues with XWayland
-      "no_focus on,match:class ^$,match:title ^$,match:xwayland 1,match:float 1,match:fullscreen 0,match:pin 0"
+      {
+        match = {
+          class = "^$";
+          title = "^$";
+          xwayland = true;
+          float = true;
+          fullscreen = false;
+          pin = false;
+        };
+        no_focus = true;
+      }
 
       # Float in the middle for clipse clipboard manager
-      "float on, match:class (clipse)"
-      "size 622 652, match:class (clipse)"
-      "stay_focused on, match:class (clipse)"
+      {match = {class = "(clipse)";}; float = true;}
+      {match = {class = "(clipse)";}; size = "622 652";}
+      {match = {class = "(clipse)";}; stay_focused = true;}
     ];
 
-    layerrule = [
+    layer_rule = [
       # Proper background blur for wofi
-      "blur on, match:namespace wofi"
-      "blur on, match:namespace waybar"
+      {match = {namespace = "wofi";}; blur = true;}
+      {match = {namespace = "waybar";}; blur = true;}
     ];
   };
 }


### PR DESCRIPTION
## Summary

- Translate every settings file under `modules/omarchy/home-manager/hyprland/` to the Lua-mode renderer (`hl.<name>(...)` calls) and flip `configType` from `hyprlang` to `lua`.
- Silences the home-manager 26.05 deprecation warning and decouples it from `home.stateVersion`.
- 80+ binds across `bind`/`bindm`/`bindel`/`bindl` collapse into a single `hl.bind(...)` list with `{ repeating, locked, mouse }` flag tables.

Per-file changes match the table in #25; dispatchers were cross-checked against the Hyprland 0.55 Lua stubs at `share/hypr/stubs/hl.meta.lua`.

## Test plan

- [x] `nix build .#nixosConfigurations.thebeast.config.system.build.toplevel` — green, no warnings
- [x] `nix eval .#…hyprland.configType` no longer prints the 26.05 deprecation warning
- [x] `luajit -bl` on the rendered `~/.config/hypr/hyprland.lua` — clean, valid Lua
- [ ] Rebuild `thebeast` and exercise the bindings live (apps launcher, workspace switches, window focus/swap/resize, mouse drag/resize, audio/brightness keys, screenshot, special workspace)
- [ ] Confirm window rules (suppress maximize, chromium tile, steam float+center, RetroArch fullscreen, opacity tiers, clipse size/float)
- [ ] Confirm monitor with HDR bringup (`bitdepth`, `cm`, sdr*, min/max luminance fields)

## Notes / follow-ups

- This PR does the migration but does not land the test infra prerequisites called out in #25 (rendered-file snapshot, headless Hyprland VM, dispatcher-name allowlist). Worth doing as a follow-up so the next Lua-API drift is caught at build time rather than as a silent missing bind.
- `autostart.nix` only had empty `exec`/`exec-once` lists, so it's left as a stub with a pointer to `hl.on("hyprland.start", ...)` for future startup commands.
- The dispatcher mapping (e.g. `movefocus, l` → `hl.dsp.focus({ direction = "left" })`, `swapwindow, l` → `hl.dsp.window.swap({ direction = "left" })`, `layoutmsg, togglesplit` → `hl.dsp.layout("togglesplit")`) follows the table in #25 and matches the names exposed by `hl.meta.lua`, but the parameter shapes of each dispatcher aren't all documented in the wiki yet — live testing on `thebeast` is the canonical verification.

Closes #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)