### PR TITLE
Wrap git & gh off home-manager (#41)

### DIFF
--- a/docs/WRAPPERS.md
+++ b/docs/WRAPPERS.md
@@ -12,10 +12,11 @@ flags. It is exposed as `pkgs.mkWrapped` by `modules/nixpkgs/overlays/mkWrapped.
 
 ```nix
 pkgs.mkWrapped {
-  pkg = pkgs.jujutsu;          # package to wrap
-  name = "jj";                 # binary in $out/bin to wrap; defaults to mainProgram/pname
-  env.JJ_CONFIG = configFile;  # attrs -> `--set KEY VALUE`
-  flags = ["--no-pager"];      # list -> `--add-flags`
+  pkg = pkgs.jujutsu;             # package to wrap
+  name = "jj";                    # binary in $out/bin to wrap; defaults to mainProgram/pname
+  env.JJ_CONFIG = configFile;     # attrs -> `--set KEY VALUE`
+  flags = ["--no-pager"];         # list -> `--add-flags`
+  extraPaths = [pkgs.git-lfs];    # list of pkgs -> `--prefix PATH` (subcommands, helpers)
 }
 ```
 
@@ -77,6 +78,28 @@ users.users.jasonbk.programs.jujutsu = {
 };
 ```
 
+## git: `formats.gitIni` + git-lfs + flattened signing
+
+`modules/programs/git.nix` bakes `settings` (a `formats.gitIni` attrset) into
+`GIT_CONFIG_GLOBAL`, folds `ignores` in as a generated `core.excludesFile`, and
+— when `lfs.enable` (default) — puts `git-lfs` on the wrapper PATH (`extraPaths`)
+and bakes the `filter.lfs.*` filters into the config. It also keeps the existing
+system-level `programs.git` (NixOS module) so git stays available system-wide.
+
+home-manager gated ssh signing on `programs.ssh`/`_1password` cross-module
+conditionals. Wrappers have no such cross-talk, so the per-user values
+(`modules/users/jasonbk/programs/git.nix`) **flatten** the conditional: signing
+keys and the `op-ssh-sign` program path are written straight into `settings`.
+
+## gh: `GH_EDITOR`, not `GH_CONFIG_DIR`
+
+`gh auth login` writes `hosts.yml` into `GH_CONFIG_DIR`, so pointing that var at
+a read-only store path (the `JJ_CONFIG`-style move) would break auth — the one
+thing the issue says must keep working. `modules/programs/gh.nix` therefore only
+pins the editor via `GH_EDITOR` and leaves `GH_CONFIG_DIR` (config + auth) in the
+real `~/.config/gh`. The `settings` option mirrors gh's config shape, but only
+`editor` is wired.
+
 ## Testing the convention
 
 `modules/programs/tests/jujutsu-wrapper.nix` (flake check `jujutsu-wrapper`) is
@@ -88,6 +111,11 @@ real default, so changing the config never touches the test.
 ```
 nix build .#checks.x86_64-linux.jujutsu-wrapper
 ```
+
+`git-wrapper` and `gh-wrapper` follow the same shape: `git-wrapper` also asserts
+`git-lfs` resolves on the wrapper PATH and the lfs filter is baked; `gh-wrapper`
+asserts the editor is pinned as `GH_EDITOR` and that `GH_CONFIG_DIR` is *not*
+touched (so auth stays in the real config dir).
 
 Each `*.nix` in `modules/programs/tests/` is a `{pkgs, inputs ? null}` function
 returning a VM test; `modules/programs/tests/default.nix` auto-registers them

--- a/modules/nixpkgs/overlays/mkWrapped.nix
+++ b/modules/nixpkgs/overlays/mkWrapped.nix
@@ -4,6 +4,7 @@ final: _prev: {
     name ? pkg.meta.mainProgram or pkg.pname,
     env ? {},
     flags ? [],
+    extraPaths ? [],
   }:
     final.symlinkJoin {
       name = "${name}-wrapped";
@@ -13,6 +14,7 @@ final: _prev: {
         wrapProgram $out/bin/${name} \
           ${final.lib.concatStringsSep " \\\n      " (
           final.lib.mapAttrsToList (k: v: "--set ${k} ${final.lib.escapeShellArg "${v}"}") env
+          ++ final.lib.optional (extraPaths != []) "--prefix PATH : ${final.lib.escapeShellArg (final.lib.makeBinPath extraPaths)}"
           ++ map (f: "--add-flags ${final.lib.escapeShellArg f}") flags
         )}
       '';

--- a/modules/programs/default.nix
+++ b/modules/programs/default.nix
@@ -1,6 +1,7 @@
 {...}: {
   imports = [
     ./fd.nix
+    ./gh.nix
     ./git.nix
     ./jujutsu.nix
     ./nushell.nix

--- a/modules/programs/gh.nix
+++ b/modules/programs/gh.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  pkgs,
+  ...
+}: let
+  yamlFormat = pkgs.formats.yaml {};
+
+  perUser = {config, ...}: let
+    cfg = config.programs.gh;
+  in {
+    options.programs.gh = {
+      enable = lib.mkEnableOption "gh (hand-rolled wrapper) in this user's environment";
+
+      package = lib.mkPackageOption pkgs "gh" {};
+
+      settings = lib.mkOption {
+        type = yamlFormat.type;
+        default = {};
+        example = {editor = "nvim";};
+        description = ''
+          gh config. Only `editor` is baked (pinned as GH_EDITOR); the rest of
+          gh's config and its auth (hosts.yml) stay in the real GH_CONFIG_DIR so
+          `gh auth login` keeps working — see docs/WRAPPERS.md.
+        '';
+      };
+    };
+
+    config = lib.mkIf cfg.enable {
+      packages = [
+        (pkgs.mkWrapped {
+          pkg = cfg.package;
+          name = "gh";
+          env = lib.optionalAttrs (cfg.settings ? editor) {
+            GH_EDITOR = cfg.settings.editor;
+          };
+        })
+      ];
+    };
+  };
+in {
+  options.users.users = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule perUser);
+  };
+}

--- a/modules/programs/git.nix
+++ b/modules/programs/git.nix
@@ -1,6 +1,70 @@
-{...}: {
-  programs.git = {
-    enable = true;
+{
+  lib,
+  pkgs,
+  ...
+}: let
+  gitIniFormat = pkgs.formats.gitIni {};
+
+  lfsFilter = {
+    clean = "git-lfs clean -- %f";
+    smudge = "git-lfs smudge -- %f";
+    process = "git-lfs filter-process";
+    required = true;
+  };
+
+  perUser = {config, ...}: let
+    cfg = config.programs.git;
+    excludesFile = pkgs.writeText "gitignore" (lib.concatStringsSep "\n" cfg.ignores);
+    bakedConfig = lib.foldl' lib.recursiveUpdate {} [
+      cfg.settings
+      (lib.optionalAttrs (cfg.ignores != []) {core.excludesFile = "${excludesFile}";})
+      (lib.optionalAttrs cfg.lfs.enable {filter.lfs = lfsFilter;})
+    ];
+  in {
+    options.programs.git = {
+      enable = lib.mkEnableOption "git (hand-rolled wrapper) in this user's environment";
+
+      package = lib.mkPackageOption pkgs "git" {};
+
+      lfs.enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Put git-lfs on the wrapper PATH and bake its filters into GIT_CONFIG_GLOBAL.";
+      };
+
+      ignores = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [];
+        example = [".DS_Store"];
+        description = "Patterns baked into a gitignore and wired as core.excludesFile.";
+      };
+
+      settings = lib.mkOption {
+        type = gitIniFormat.type;
+        default = {};
+        example = {init.defaultBranch = "main";};
+        description = "Settings baked into this user's git wrapper via GIT_CONFIG_GLOBAL.";
+      };
+    };
+
+    config = lib.mkIf cfg.enable {
+      packages = [
+        (pkgs.mkWrapped {
+          pkg = cfg.package;
+          name = "git";
+          extraPaths = lib.optional cfg.lfs.enable pkgs.git-lfs;
+          env.GIT_CONFIG_GLOBAL = gitIniFormat.generate "gitconfig" bakedConfig;
+        })
+      ];
+    };
+  };
+in {
+  options.users.users = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule perUser);
+  };
+
+  config.programs.git = {
+    enable = lib.mkDefault true;
     lfs.enable = true;
   };
 }

--- a/modules/programs/tests/gh-wrapper.nix
+++ b/modules/programs/tests/gh-wrapper.nix
@@ -1,0 +1,39 @@
+{
+  pkgs,
+  inputs ? null,
+}: let
+  sentinel = "wrapper-editor-4b1d";
+  pkgsWrapped = pkgs.extend (import ../../nixpkgs/overlays/mkWrapped.nix);
+in
+  pkgs.testers.nixosTest {
+    name = "gh-wrapper";
+
+    nodes.machine = {
+      nixpkgs.pkgs = pkgsWrapped;
+      imports = [../gh.nix];
+
+      users.users.tester = {
+        isNormalUser = true;
+        programs.gh = {
+          enable = true;
+          settings.editor = sentinel;
+        };
+      };
+    };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+
+      gh = machine.succeed("su -l tester -c 'readlink -f $(command -v gh)'").strip()
+
+      with subtest("the wrapped gh is in the user's environment and runs"):
+          machine.succeed("su -l tester -c 'gh --version'")
+
+      with subtest("the wrapper pins settings.editor as GH_EDITOR"):
+          machine.succeed(f"grep -aq 'GH_EDITOR' {gh}")
+          machine.succeed(f"grep -aq '${sentinel}' {gh}")
+
+      with subtest("the wrapper leaves GH_CONFIG_DIR alone so gh auth login keeps owning hosts.yml"):
+          machine.fail(f"grep -aq 'GH_CONFIG_DIR' {gh}")
+    '';
+  }

--- a/modules/programs/tests/git-wrapper.nix
+++ b/modules/programs/tests/git-wrapper.nix
@@ -1,0 +1,49 @@
+{
+  pkgs,
+  inputs ? null,
+}: let
+  sentinel = "wrapper-loaded-9c2e";
+  pkgsWrapped = pkgs.extend (import ../../nixpkgs/overlays/mkWrapped.nix);
+in
+  pkgs.testers.nixosTest {
+    name = "git-wrapper";
+
+    nodes.machine = {
+      nixpkgs.pkgs = pkgsWrapped;
+      imports = [../git.nix];
+
+      users.users.tester = {
+        isNormalUser = true;
+        programs.git = {
+          enable = true;
+          ignores = [".DS_Store"];
+          settings.wrapper.sentinel = sentinel;
+        };
+      };
+    };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+
+      with subtest("the wrapped git is in the user's environment and runs"):
+          machine.succeed("su -l tester -c 'git --version'")
+
+      with subtest("the wrapper loads the user's baked GIT_CONFIG_GLOBAL"):
+          got = machine.succeed(
+              "su -l tester -c 'git config --global --get wrapper.sentinel'"
+          ).strip()
+          assert got == "${sentinel}", f"wrapper did not load baked config: {got!r}"
+
+          got = machine.succeed(
+              "su -l tester -c 'GIT_CONFIG_GLOBAL=/dev/null git config --global --get wrapper.sentinel'"
+          ).strip()
+          assert got == "${sentinel}", f"wrapper did not pin GIT_CONFIG_GLOBAL: {got!r}"
+
+      with subtest("git-lfs rides on the wrapper PATH and its filter is baked in"):
+          machine.succeed("su -l tester -c 'git lfs version'")
+          required = machine.succeed(
+              "su -l tester -c 'git config --global --get filter.lfs.required'"
+          ).strip()
+          assert required == "true", f"lfs filter not baked: {required!r}"
+    '';
+  }

--- a/modules/users/jasonbk/programs/default.nix
+++ b/modules/users/jasonbk/programs/default.nix
@@ -1,5 +1,7 @@
 {...}: {
   imports = [
+    ./gh.nix
+    ./git.nix
     ./jujutsu.nix
   ];
 }

--- a/modules/users/jasonbk/programs/gh.nix
+++ b/modules/users/jasonbk/programs/gh.nix
@@ -1,0 +1,6 @@
+{...}: {
+  users.users.jasonbk.programs.gh = {
+    enable = true;
+    settings.editor = "nvim";
+  };
+}

--- a/modules/users/jasonbk/programs/gh.nix
+++ b/modules/users/jasonbk/programs/gh.nix
@@ -1,6 +1,8 @@
 {...}: {
   users.users.jasonbk.programs.gh = {
     enable = true;
+    # TODO: replace the "nvim" literal with users.users.jasonbk.editor
+    # https://github.com/jasonboukheir/dotfiles/issues/62
     settings.editor = "nvim";
   };
 }

--- a/modules/users/jasonbk/programs/git.nix
+++ b/modules/users/jasonbk/programs/git.nix
@@ -13,6 +13,8 @@
         signingKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBGEXFObvyFbGAgq3Lob/+2SPBXfFBmguTmJDLcJlysJ";
       };
       init.defaultBranch = "main";
+      # TODO: replace the "nvim" literals with users.users.jasonbk.editor
+      # https://github.com/jasonboukheir/dotfiles/issues/62
       core.editor = "nvim";
       merge.tool = "nvim";
       diff.tool = "nvim";

--- a/modules/users/jasonbk/programs/git.nix
+++ b/modules/users/jasonbk/programs/git.nix
@@ -1,0 +1,24 @@
+{
+  lib,
+  pkgs,
+  ...
+}: {
+  users.users.jasonbk.programs.git = {
+    enable = true;
+    ignores = [".DS_Store"];
+    settings = {
+      user = {
+        name = "Jason Elie Bou Kheir";
+        email = "5115126+jasonboukheir@users.noreply.github.com";
+        signingKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBGEXFObvyFbGAgq3Lob/+2SPBXfFBmguTmJDLcJlysJ";
+      };
+      init.defaultBranch = "main";
+      core.editor = "nvim";
+      merge.tool = "nvim";
+      diff.tool = "nvim";
+      commit.gpgsign = true;
+      gpg.format = "ssh";
+      "gpg \"ssh\"".program = lib.getExe' pkgs._1password-gui "op-ssh-sign";
+    };
+  };
+}

--- a/modules/users/jasonbk/programs/git.nix
+++ b/modules/users/jasonbk/programs/git.nix
@@ -7,17 +7,20 @@
     enable = true;
     ignores = [".DS_Store"];
     settings = {
-      user = {
-        name = "Jason Elie Bou Kheir";
-        email = "5115126+jasonboukheir@users.noreply.github.com";
-        signingKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBGEXFObvyFbGAgq3Lob/+2SPBXfFBmguTmJDLcJlysJ";
-      };
+      # TODO: replace name/email with users.users.jasonbk.identity
+      # https://github.com/jasonboukheir/dotfiles/issues/63
+      user.name = "Jason Elie Bou Kheir";
+      user.email = "5115126+jasonboukheir@users.noreply.github.com";
       init.defaultBranch = "main";
       # TODO: replace the "nvim" literals with users.users.jasonbk.editor
       # https://github.com/jasonboukheir/dotfiles/issues/62
       core.editor = "nvim";
       merge.tool = "nvim";
       diff.tool = "nvim";
+      # TODO: ssh signing flattened from HM ssh/1Password; fold back into the
+      # ssh/1Password module once it lands (op-ssh-sign path is linux-only).
+      # https://github.com/jasonboukheir/dotfiles/issues/46
+      user.signingKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBGEXFObvyFbGAgq3Lob/+2SPBXfFBmguTmJDLcJlysJ";
       commit.gpgsign = true;
       gpg.format = "ssh";
       "gpg \"ssh\"".program = lib.getExe' pkgs._1password-gui "op-ssh-sign";


### PR DESCRIPTION
Continues the hand-rolled wrapper migration (POC: jujutsu, #60) for the remaining cleanest cases. Closes part of #41.

Purely additive and mirrors the jujutsu POC: capability module + per-user values + VM test, wired through the same `modules/programs` / `modules/users` surfaces. HM modules and per-host rollout are left for follow-up (same staging as jujutsu).

## git — `modules/programs/git.nix`
- Per-user wrapper capability mirroring `jujutsu.nix`: `settings` (`formats.gitIni`) baked into `GIT_CONFIG_GLOBAL`; `ignores` folded in as a generated `core.excludesFile`.
- `lfs.enable` (default `true`) puts `git-lfs` on the wrapper PATH (new `mkWrapped` `extraPaths`) **and** bakes the `filter.lfs.*` filters into the config.
- Keeps the existing system-level `programs.git` so git stays available system-wide.
- `jasonbk` values **flatten** the HM `programs.ssh` / `_1password` signing conditional straight into `settings` (the `op-ssh-sign` program path + signing key), since wrappers have no cross-module conditionals.

## gh — `modules/programs/gh.nix`
- Pins the editor via `GH_EDITOR` **only**. Deliberately does **not** set `GH_CONFIG_DIR` — pointing it at a read-only store path would break `gh auth login` (it writes `hosts.yml` there). Auth stays in the real `~/.config/gh`.

## mkWrapped
- Gains `extraPaths` → `--prefix PATH`, for subcommands/helpers like `git-lfs`.

## Tests
`git-wrapper` and `gh-wrapper` NixOS VM checks (auto-registered) assert the plumbing, not the config:
- `git-wrapper`: wrapped `git` runs; baked `GIT_CONFIG_GLOBAL` loads and is pinned (override ignored); `git lfs version` resolves on PATH; `filter.lfs.required` is baked.
- `gh-wrapper`: wrapped `gh` runs; `GH_EDITOR` is pinned from `settings.editor`; `GH_CONFIG_DIR` is **not** touched.

Both pass locally (`nix build .#checks.x86_64-linux.{git,gh}-wrapper`). `litus` evaluates with the new per-user values wired in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)