### PR TITLE
stylix: per-user theming without home-manager (#38)

### DIFF
--- a/docs/WRAPPERS.md
+++ b/docs/WRAPPERS.md
@@ -122,7 +122,11 @@ home-manager's stylix module turned the **system** stylix config
   `config.stylix.*` — so a user inherits the system theme but can override any of
   them (e.g. `users.users.<name>.stylix.colors` for a different base16 scheme).
   The system reads are guarded, so importing the foundation onto a host with no
-  system stylix is a no-op rather than an eval error.
+  system stylix is a no-op rather than an eval error. `stylix.cursor` is a
+  NixOS-only option (the darwin stylix module never declares it), so the
+  per-user `cursor.{name,package,size}` is a `nullOr` that inherits the themed
+  system cursor on Linux and resolves to `null` on darwin — a cursor target
+  keys off `cursor.name != null` and stays inactive where there is no cursor.
 - **Targets** (`modules/stylix/users/<app>.nix`): mirror HM's
   `stylix.targets.<app>`. A target declares
   `users.users.<name>.stylix.targets.<app>.enable` (defaulting to the user's

--- a/docs/WRAPPERS.md
+++ b/docs/WRAPPERS.md
@@ -100,6 +100,41 @@ pins the editor via `GH_EDITOR` and leaves `GH_CONFIG_DIR` (config + auth) in th
 real `~/.config/gh`. The `settings` option mirrors gh's config shape, but only
 `editor` is wired.
 
+## ghostty: `--config-file` + stylix theming
+
+`modules/programs/ghostty.nix` bakes `settings` into a `writeText` config and
+loads it via `flags = ["--config-file=${file}"]`. List values render as repeated
+`key = item` lines, so `palette = ["0=#…" "1=#…"]` becomes ghostty's repeated
+`palette = N=#…` form. The user's own `~/.config/ghostty/config` still loads, so
+hand edits win on conflicts.
+
+## stylix: per-user theming without the HM stylix module
+
+home-manager's stylix module turned the **system** stylix config
+(`stylix-nixos`/`stylix-darwin`) into per-`~/.config` color files. Dropping HM
+([#38]) drops those, so `modules/stylix/users/` re-creates the mechanism on the
+`users.users.<name>` submodule — the same surface the wrappers already extend.
+
+- **Foundation** (`modules/stylix/users/options.nix`): declares
+  `users.users.<name>.stylix.{enable,polarity,colors,fonts,opacity}`. Each option
+  **defaults from the system stylix config** — `colors` from
+  `config.lib.stylix.colors`, `polarity`/`fonts`/`opacity`/`enable` from
+  `config.stylix.*` — so a user inherits the system theme but can override any of
+  them (e.g. `users.users.<name>.stylix.colors` for a different base16 scheme).
+  The system reads are guarded, so importing the foundation onto a host with no
+  system stylix is a no-op rather than an eval error.
+- **Targets** (`modules/stylix/users/<app>.nix`): mirror HM's
+  `stylix.targets.<app>`. A target declares
+  `users.users.<name>.stylix.targets.<app>.enable` (defaulting to the user's
+  `stylix.enable`) and, when both it and the app wrapper are enabled, writes the
+  palette into that wrapper's `settings` via `lib.mkDefault` — so the user's own
+  `settings` still win. `ghostty.nix` is the first target: it maps base16 →
+  `background`/`foreground`/`selection-*`/`cursor-*` and the 16 ANSI `palette`
+  slots.
+
+This keeps the wrapper (a tool) and the theme (a target) separate, exactly as
+upstream stylix splits `programs.<app>` from `stylix.targets.<app>`.
+
 ## Testing the convention
 
 `modules/programs/tests/jujutsu-wrapper.nix` (flake check `jujutsu-wrapper`) is
@@ -116,6 +151,14 @@ nix build .#checks.x86_64-linux.jujutsu-wrapper
 `git-lfs` resolves on the wrapper PATH and the lfs filter is baked; `gh-wrapper`
 asserts the editor is pinned as `GH_EDITOR` and that `GH_CONFIG_DIR` is *not*
 touched (so auth stays in the real config dir).
+
+`ghostty-stylix` proves the per-user stylix path end-to-end: it feeds a set of
+arbitrary base16 ids into `users.users.<name>.stylix.colors`, then asserts the
+wrapper injects a baked `--config-file` whose rendered config carries those ids
+on the right ghostty keys, and that `ghostty +show-config` parses the theme and
+resolves the palette. Like the others it asserts the **plumbing**
+(`stylix.colors → target → ghostty.settings → --config-file → ghostty`), never a
+specific scheme.
 
 Each `*.nix` in `modules/programs/tests/` is a `{pkgs, inputs ? null}` function
 returning a VM test; `modules/programs/tests/default.nix` auto-registers them

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -4,5 +4,6 @@
     ./nixpkgs
     ./programs
     ./stylix
+    ./stylix/users
   ];
 }

--- a/modules/programs/default.nix
+++ b/modules/programs/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ./fd.nix
     ./gh.nix
+    ./ghostty.nix
     ./git.nix
     ./jujutsu.nix
     ./nushell.nix

--- a/modules/programs/ghostty.nix
+++ b/modules/programs/ghostty.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  pkgs,
+  ...
+}: let
+  renderValue = v:
+    if lib.isBool v
+    then lib.boolToString v
+    else toString v;
+
+  renderEntry = key: value:
+    if lib.isList value
+    then map (item: "${key} = ${renderValue item}") value
+    else ["${key} = ${renderValue value}"];
+
+  renderConfig = settings:
+    lib.concatStringsSep "\n" (lib.concatLists (lib.mapAttrsToList renderEntry settings)) + "\n";
+
+  perUser = {config, ...}: let
+    cfg = config.programs.ghostty;
+    configFile = pkgs.writeText "ghostty-config" (renderConfig cfg.settings);
+  in {
+    options.programs.ghostty = {
+      enable = lib.mkEnableOption "ghostty (hand-rolled wrapper) in this user's environment";
+
+      package = lib.mkPackageOption pkgs "ghostty" {};
+
+      settings = lib.mkOption {
+        type = with lib.types; attrsOf (oneOf [bool int str (listOf str)]);
+        default = {};
+        example = {
+          theme = "GruvboxDark";
+          palette = ["0=#1d2021" "1=#cc241d"];
+        };
+        description = ''
+          ghostty config baked into this user's wrapper and loaded via
+          `--config-file`. List values render as repeated `key = item` lines
+          (e.g. `palette`). The stylix target under `modules/stylix/users`
+          populates the color keys; the user's own `~/.config/ghostty/config`
+          still loads and wins on conflicts.
+        '';
+      };
+    };
+
+    config = lib.mkIf cfg.enable {
+      packages = [
+        (pkgs.mkWrapped {
+          pkg = cfg.package;
+          name = "ghostty";
+          flags = lib.optional (cfg.settings != {}) "--config-file=${configFile}";
+        })
+      ];
+    };
+  };
+in {
+  options.users.users = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule perUser);
+  };
+}

--- a/modules/programs/tests/ghostty-stylix.nix
+++ b/modules/programs/tests/ghostty-stylix.nix
@@ -1,0 +1,77 @@
+{
+  pkgs,
+  inputs ? null,
+}: let
+  pkgsWrapped = pkgs.extend (import ../../nixpkgs/overlays/mkWrapped.nix);
+
+  # Arbitrary, mutually distinct base16 ids so each slot is greppable in the
+  # rendered ghostty config. The values are meaningless — the test only proves
+  # that whatever palette goes into stylix comes out the far side as ghostty
+  # colors.
+  colors = {
+    base00 = "010203";
+    base01 = "040506";
+    base02 = "070809";
+    base03 = "0a0b0c";
+    base04 = "0d0e0f";
+    base05 = "101112";
+    base06 = "131415";
+    base07 = "161718";
+    base08 = "191a1b";
+    base09 = "1c1d1e";
+    base0A = "1f2021";
+    base0B = "222324";
+    base0C = "252627";
+    base0D = "28292a";
+    base0E = "2b2c2d";
+    base0F = "2e2f30";
+  };
+in
+  pkgs.testers.nixosTest {
+    name = "ghostty-stylix";
+
+    nodes.machine = {
+      nixpkgs.pkgs = pkgsWrapped;
+      imports = [
+        ../ghostty.nix
+        ../../stylix/users
+      ];
+
+      users.users.tester = {
+        isNormalUser = true;
+        stylix = {
+          enable = true;
+          inherit colors;
+        };
+        programs.ghostty.enable = true;
+      };
+    };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+
+      ghostty = machine.succeed("su -l tester -c 'readlink -f $(command -v ghostty)'").strip()
+
+      with subtest("the wrapper injects a baked --config-file"):
+          machine.succeed(f"grep -aq -- '--config-file=' {ghostty}")
+
+      config = machine.succeed(
+          f"grep -aoE '/nix/store/[a-z0-9]{{32}}-ghostty-config' {ghostty} | head -n1"
+      ).strip()
+      assert config, "no baked ghostty config path found in the wrapper"
+
+      with subtest("stylix base16 ids land in the baked ghostty config"):
+          machine.succeed(f"grep -aq 'background = #${colors.base00}' {config}")
+          machine.succeed(f"grep -aq 'foreground = #${colors.base05}' {config}")
+          machine.succeed(f"grep -aq 'selection-background = #${colors.base02}' {config}")
+          # base16 → ansi: slot 1 = base08 (red), slot 4 = base0D (blue).
+          machine.succeed(f"grep -aq 'palette = 1=#${colors.base08}' {config}")
+          machine.succeed(f"grep -aq 'palette = 4=#${colors.base0D}' {config}")
+
+      with subtest("the wrapped ghostty launches and accepts the injected theme"):
+          # The wrapper prepends --config-file=<theme>, so validating with no
+          # explicit config exercises the injected palette end-to-end; ghostty
+          # exits non-zero on a malformed color/key.
+          machine.succeed("su -l tester -c 'ghostty +validate-config'")
+    '';
+  }

--- a/modules/stylix/users/default.nix
+++ b/modules/stylix/users/default.nix
@@ -1,0 +1,6 @@
+{...}: {
+  imports = [
+    ./options.nix
+    ./ghostty.nix
+  ];
+}

--- a/modules/stylix/users/default.nix
+++ b/modules/stylix/users/default.nix
@@ -1,4 +1,13 @@
 {...}: {
+  # ghostty is the first per-user stylix target; more targets re-baking what
+  # HM-stylix used to emit land with their module wrappers:
+  #   claude-code (polarity -> dark-ansi/light-ansi):
+  #     https://github.com/jasonboukheir/dotfiles/issues/45
+  #   nvf (base16 scheme):
+  #     https://github.com/jasonboukheir/dotfiles/issues/43
+  #   btop / waybar / mako / wofi:
+  #     https://github.com/jasonboukheir/dotfiles/issues/48
+  # Tracked under https://github.com/jasonboukheir/dotfiles/issues/38
   imports = [
     ./options.nix
     ./ghostty.nix

--- a/modules/stylix/users/ghostty.nix
+++ b/modules/stylix/users/ghostty.nix
@@ -24,6 +24,10 @@
     stylix = config.stylix;
     c = stylix.colors;
 
+    # TODO: only the base16 palette is mapped; wire `stylix.fonts` into
+    # ghostty's font-family/font-size and `stylix.opacity.terminal` into
+    # background-opacity to match HM-stylix's ghostty target.
+    # https://github.com/jasonboukheir/dotfiles/issues/44
     themed = {
       background = "#${c.base00}";
       foreground = "#${c.base05}";

--- a/modules/stylix/users/ghostty.nix
+++ b/modules/stylix/users/ghostty.nix
@@ -1,0 +1,52 @@
+{lib, ...}: let
+  # base16 → 16-colour ANSI terminal slots, the standard base16 mapping
+  # (bright variants reuse the normal accent hues).
+  ansiPalette = c: [
+    c.base00 # 0  black
+    c.base08 # 1  red
+    c.base0B # 2  green
+    c.base0A # 3  yellow
+    c.base0D # 4  blue
+    c.base0E # 5  magenta
+    c.base0C # 6  cyan
+    c.base05 # 7  white
+    c.base03 # 8  bright black
+    c.base08 # 9  bright red
+    c.base0B # 10 bright green
+    c.base0A # 11 bright yellow
+    c.base0D # 12 bright blue
+    c.base0E # 13 bright magenta
+    c.base0C # 14 bright cyan
+    c.base07 # 15 bright white
+  ];
+
+  perUser = {config, ...}: let
+    stylix = config.stylix;
+    c = stylix.colors;
+
+    themed = {
+      background = "#${c.base00}";
+      foreground = "#${c.base05}";
+      cursor-color = "#${c.base05}";
+      cursor-text = "#${c.base00}";
+      selection-background = "#${c.base02}";
+      selection-foreground = "#${c.base05}";
+      palette = lib.imap0 (i: hex: "${toString i}=#${hex}") (ansiPalette c);
+    };
+  in {
+    options.stylix.targets.ghostty.enable =
+      lib.mkEnableOption "stylix theming for this user's ghostty wrapper"
+      // {
+        default = stylix.enable;
+        defaultText = lib.literalExpression "config.stylix.enable";
+      };
+
+    config = lib.mkIf (config.stylix.targets.ghostty.enable && config.programs.ghostty.enable) {
+      programs.ghostty.settings = lib.mapAttrs (_: lib.mkDefault) themed;
+    };
+  };
+in {
+  options.users.users = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule perUser);
+  };
+}

--- a/modules/stylix/users/options.nix
+++ b/modules/stylix/users/options.nix
@@ -68,6 +68,13 @@
         description = "Opacity settings for this user's wrappers. Defaults to the system stylix opacity.";
       };
 
+      # TODO: no consumer yet — the session env (XCURSOR_*/HYPRCURSOR_*), GTK
+      # cursor-theme, and installing `cursor.package` into the icon path land
+      # with the Hyprland session generator
+      # (https://github.com/jasonboukheir/dotfiles/issues/40) and the
+      # omarchy/Hyprland desktop set
+      # (https://github.com/jasonboukheir/dotfiles/issues/48), replacing
+      # modules/omarchy/home-manager/hyprland/envs.nix.
       cursor = {
         name = lib.mkOption {
           type = lib.types.nullOr lib.types.str;

--- a/modules/stylix/users/options.nix
+++ b/modules/stylix/users/options.nix
@@ -13,6 +13,15 @@
     then lib.filterAttrs (_: lib.isString) config.lib.stylix.colors
     else {};
 
+  # `stylix.cursor` is a NixOS/HM-stylix option; the darwin stylix module
+  # never declares it (macOS has no X cursor themes). Guard on its presence
+  # so the per-user cursor inherits the themed system cursor on Linux and
+  # falls back to null on darwin instead of throwing.
+  systemCursor =
+    if (config ? stylix && config.stylix ? cursor)
+    then config.stylix.cursor
+    else {};
+
   perUser = _: {
     options.stylix = {
       enable = lib.mkOption {
@@ -57,6 +66,33 @@
         default = systemStylix.opacity or {};
         defaultText = lib.literalExpression "config.stylix.opacity";
         description = "Opacity settings for this user's wrappers. Defaults to the system stylix opacity.";
+      };
+
+      cursor = {
+        name = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = systemCursor.name or null;
+          defaultText = lib.literalExpression "config.stylix.cursor.name or null";
+          description = ''
+            Cursor theme name. Inherits the themed system stylix cursor on
+            NixOS; null where the system stylix has no cursor (darwin), which
+            leaves cursor-consuming targets inactive.
+          '';
+        };
+
+        package = lib.mkOption {
+          type = lib.types.nullOr lib.types.package;
+          default = systemCursor.package or null;
+          defaultText = lib.literalExpression "config.stylix.cursor.package or null";
+          description = "Cursor theme package a target installs into this user's icon path. Inherits the system stylix cursor when defined.";
+        };
+
+        size = lib.mkOption {
+          type = lib.types.int;
+          default = systemCursor.size or 24;
+          defaultText = lib.literalExpression "config.stylix.cursor.size or 24";
+          description = "Cursor size (XCURSOR_SIZE/HYPRCURSOR_SIZE). Inherits the system stylix cursor size when defined.";
+        };
       };
     };
   };

--- a/modules/stylix/users/options.nix
+++ b/modules/stylix/users/options.nix
@@ -1,0 +1,67 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  systemStylix =
+    if config ? stylix
+    then config.stylix
+    else {};
+
+  systemColors =
+    if (config ? lib && config.lib ? stylix && config.lib.stylix ? colors)
+    then lib.filterAttrs (_: lib.isString) config.lib.stylix.colors
+    else {};
+
+  perUser = _: {
+    options.stylix = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = systemStylix.enable or false;
+        defaultText = lib.literalExpression "config.stylix.enable";
+        description = ''
+          Whether to theme this user's wrappers from stylix. Defaults to the
+          system stylix setting; the per-app targets under
+          `modules/stylix/users` key off this.
+        '';
+      };
+
+      polarity = lib.mkOption {
+        type = lib.types.enum ["either" "light" "dark"];
+        default = systemStylix.polarity or "dark";
+        defaultText = lib.literalExpression "config.stylix.polarity";
+        description = "Theme polarity for this user. Defaults to the system stylix polarity.";
+      };
+
+      colors = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = systemColors;
+        defaultText = lib.literalExpression "config.lib.stylix.colors";
+        example = lib.literalExpression ''{base00 = "1d2021"; base05 = "ebdbb2";}'';
+        description = ''
+          base16 palette (`base00`..`base0F`, hex without a leading `#`) used to
+          theme this user's wrappers. Defaults to the resolved system stylix
+          palette; override to give this user a different scheme.
+        '';
+      };
+
+      fonts = lib.mkOption {
+        type = lib.types.attrs;
+        default = systemStylix.fonts or {};
+        defaultText = lib.literalExpression "config.stylix.fonts";
+        description = "Fonts for this user's wrappers. Defaults to the system stylix fonts.";
+      };
+
+      opacity = lib.mkOption {
+        type = lib.types.attrs;
+        default = systemStylix.opacity or {};
+        defaultText = lib.literalExpression "config.stylix.opacity";
+        description = "Opacity settings for this user's wrappers. Defaults to the system stylix opacity.";
+      };
+    };
+  };
+in {
+  options.users.users = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule perUser);
+  };
+}


### PR DESCRIPTION
Foundation for #38 (part of #36): reproduce stylix per-app theming **without** the home-manager stylix module, split **per user** so each user can inherit or override their own colors/theming.

## What this does

Mirrors the upstream stylix split of `programs.<app>` (the tool) vs `stylix.targets.<app>` (the theme), but on the hand-rolled `users.users.<name>` wrapper layer.

- **Foundation** — `modules/stylix/users/options.nix` declares `users.users.<name>.stylix.{enable,polarity,colors,fonts,opacity}`. Each option **defaults from the system stylix config** (`config.lib.stylix.colors`, `config.stylix.{polarity,fonts,opacity,enable}`), so a user inherits the system theme by default but can override any piece — e.g. set `users.users.<name>.stylix.colors` to a different base16 palette. System reads are guarded, so importing the foundation onto a host with no system stylix is a no-op rather than an eval error.
- **First target** — `modules/stylix/users/ghostty.nix` mirrors `stylix.targets.ghostty`: maps base16 → ghostty `background`/`foreground`/`selection-*`/`cursor-*` and the 16 ANSI `palette` slots, written into the wrapper's `settings` via `lib.mkDefault` (the user's own settings still win).
- **Ghostty wrapper** — `modules/programs/ghostty.nix`, a hand-rolled `symlinkJoin`/`makeWrapper` wrapper following the git/gh/jj convention: `settings` → `writeText` → loaded via `--config-file`.

Wired only into the NixOS/darwin module tree (`modules/default.nix`), **not** the HM-only `fedora`/`work-devserver` configs. Fully opt-in: ghostty stays unwrapped until a host enables `users.users.<name>.programs.ghostty.enable`.

## Test

`modules/programs/tests/ghostty-stylix.nix` (flake check `ghostty-stylix`) is a NixOS VM test in the git/gh/jj style. It feeds a set of **arbitrary, distinct base16 ids** into `users.users.<name>.stylix.colors`, then asserts:

1. the wrapper injects a baked `--config-file`,
2. those ids render onto the correct ghostty keys (`background`, `foreground`, `selection-background`, ANSI `palette` slots), and
3. the **wrapped** `ghostty +validate-config` launches and accepts the injected theme end-to-end (non-zero on a malformed color/key).

Like the sibling tests it asserts the **plumbing** (`stylix.colors → target → ghostty.settings → --config-file → ghostty`), never a specific scheme.

```
nix build .#checks.x86_64-linux.ghostty-stylix
```

Verified `nixosConfigurations.{litus,brutus,thebeast}` and `darwinConfigurations.{jasonbk-mac,Jasons-MacBook-Pro}` still evaluate and that per-user stylix inherits the system palette (`1a1726` on stylix-enabled hosts); the HM-only `homeConfigurations` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)