### PR TITLE
my: namespaced wrapped-package surface (#36)

### DIFF
--- a/docs/plans/2026-06-09-my-namespace-wrappers-design-final.md
+++ b/docs/plans/2026-06-09-my-namespace-wrappers-design-final.md
@@ -1,0 +1,362 @@
+# Design: `my.*` namespace for wrapped programs
+
+Migrating off home-manager (epic [#36]) introduced per-user hand-rolled wrappers
+under `programs.<tool>` / `users.users.<name>.programs.<tool>`. This design
+reorganizes that into a dedicated `my.*` namespace with explicit
+system-vs-per-user semantics, a single program-definition contract, and three
+platform consumers, all under `modules/my/`.
+
+## Goals
+
+- `my.<tool>.enable` installs a configured (wrapped) package **system-wide** (all
+  users).
+- `users.users.<name>.my.<tool>.enable` installs it **for one user**, whose
+  config **cascades from** and **deep-merges over** the system config, and whose
+  wrapper **shadows** the system one in that user's PATH.
+- One reorganized tree, `modules/my/`, with three platform modules
+  (`nixos.nix`, `nix-darwin.nix`, `home-manager.nix`) consuming one set of
+  program definitions.
+- `my.*` is **only** "configure a package and install it in the right
+  environment." It never sets system state (shell registration, login shell,
+  services). Those stay on normal NixOS/darwin options, out of scope here.
+
+## Why `my.*`
+
+Short, collision-free with upstream `programs.*` (which carries hundreds of
+NixOS/HM options). The current scheme overloads `programs.*`, which both risks
+collisions and conflates "native upstream module" with "our wrapper." A private
+prefix cleanly separates our surface.
+
+## Directory layout
+
+```
+modules/my/
+  lib.nix              # framework: builds the option tree + cascade + install
+  programs/
+    default.nix        # collects all program defs into an attrset
+    git.nix  jujutsu.nix  gh.nix  starship.nix  ghostty.nix
+    fish.nix  direnv.nix  nvf/  fd.nix  rg.nix  nushell/
+  system-scope.nix     # shared system+per-user core for nixos & nix-darwin
+  nixos.nix            # thin: imports system-scope, installs into NixOS surfaces
+  nix-darwin.nix       # thin: imports system-scope, installs into darwin surfaces
+  home-manager.nix     # standalone-HM: my.<tool> (single user) -> home.packages
+  values/
+    jasonbk.nix        # jasonbk's per-user values (users.users.jasonbk.my.*)
+  tests/
+    default.nix        # auto-registers every *.nix as a flake check
+    <tool>-wrapper.nix # plumbing assertions per tool
+```
+
+`pkgs.mkWrapped` (`modules/nixpkgs/overlays/mkWrapped.nix`) stays as-is — the
+build primitive every package program uses.
+
+## The program-definition contract
+
+Every `modules/my/programs/<tool>.nix` is a function returning **one shape**:
+
+```nix
+{ lib, pkgs }: {
+  name = "jujutsu";              # key under my.<name> / users.users.<n>.my.<name>
+  defaultPackage = "jujutsu";    # attr name into pkgs for mkPackageOption
+  options = {                    # tool-specific options ONLY (freeform/scalars)
+    settings = lib.mkOption {
+      type = (pkgs.formats.toml {}).type;
+      default = {};
+      description = "Baked into this jj wrapper via JJ_CONFIG.";
+    };
+  };
+  build = { cfg, specialArgs }: pkgs.mkWrapped {   # resolved cfg -> installed pkg
+    pkg = cfg.package;
+    name = "jj";
+    env.JJ_CONFIG = (pkgs.formats.toml {}).generate "jj-config.toml" cfg.settings;
+  };
+}
+```
+
+`lib.nix` injects the **universal** options into every tool, so tool files never
+declare them:
+
+- `enable` — `mkEnableOption`.
+- `package` — `mkPackageOption pkgs defaultPackage {}`.
+- `finalPackage` — read-only, `= build { cfg = <this scope's resolved cfg>; inherit specialArgs; }`.
+
+There is no `native`/`system`/`user`/`userUnsupported` distinction: tools that
+used to rely on system-level shell integration (fish, direnv) bake that
+integration into their wrapper instead (see "fish & direnv" below).
+
+`build` receives `specialArgs` so nvf can read `neovimConfiguration` (see "nvf").
+
+## Option scopes & cascade
+
+`lib.nix` defines **one** shared submodule type from the program defs (the
+`my.<tool>` surface: `enable`/`package`/`finalPackage` + each tool's options) and
+uses it for **both** scopes — no two parallel option trees to keep in sync. It is
+built with `lib.types.submoduleWith { specialArgs = { … }; modules = [ … ]; }` so
+the submodule receives `neovimConfiguration` (plain `submodule`s do **not**
+inherit the parent `nixosSystem`/`darwinSystem` `specialArgs` — verified in
+review, C2).
+
+**System scope** — declared by every platform module:
+
+```nix
+options.my = mkOption { type = myProgramsSubmodule; default = {}; };
+# -> config.my.<tool>.{enable,package,finalPackage,...}
+```
+
+**Per-user scope** — declared by `nixos.nix`/`nix-darwin.nix` only, by
+module-merging the same submodule type onto `users.users.<name>`:
+
+```nix
+options.users.users = mkOption {
+  type = attrsOf (submodule { options.my = mkOption { type = myProgramsSubmodule; default = {}; }; });
+};
+```
+
+**Cascade rules** — implemented in the platform module (which *does* receive
+specialArgs and the top-level `config`) by pushing the system config into each
+user's `my` as **per-leaf** `mkDefault` definitions:
+
+- `enable` defaults to **`false`** (explicit per-user opt-in). A system-enabled
+  tool therefore does **not** redundantly fan a per-user copy into every user
+  profile; users opt in only to override.
+- For every **other** option, the cascade recurses the system value and wraps
+  **each leaf** in `lib.mkDefault` (a `mapAttrsRecursive`-style walk), then sets
+  that as a config definition on `users.users.<n>.my.<tool>`:
+
+  ```nix
+  # per user, per tool, in the platform module:
+  users.users.<n>.my.<tool> = recursiveMkDefault (removeAttrs config.my.<tool> ["enable" "finalPackage"]);
+  ```
+
+  This is the **load-bearing mechanic** and the one the review proved must be
+  per-leaf: a whole-attrset `mkDefault` is a single low-priority definition that
+  the module system drops entirely once the user sets the option, silently
+  losing all system keys. Per-leaf `mkDefault` instead **deep-merges** nested
+  keys with the user's explicit settings while letting the user **win on
+  scalars** (verified empirically). List leaves are replaced, not concatenated
+  (intended). This is exactly the pattern `modules/stylix/users/ghostty.nix:49`
+  (`lib.mapAttrs (_: lib.mkDefault) themed`) already uses for its target.
+
+Example:
+
+```nix
+my.git.settings.init.defaultBranch = "main";                # system
+users.users.alice.my.git = {                                # alice opts in
+  enable = true;
+  settings.user.email = "a@x";                              # merges over system
+};
+# alice's wrapper: { init.defaultBranch="main"; user.email="a@x"; }
+# bob: no per-user entry -> uses the system wrapper unchanged
+```
+
+## Installation surfaces & PATH precedence
+
+| Module | `my.<tool>.enable` | `users.users.<n>.my.<tool>.enable` |
+|---|---|---|
+| `nixos.nix` | `environment.systemPackages += finalPackage` | `users.users.<n>.packages += finalPackage` |
+| `nix-darwin.nix` | `environment.systemPackages += finalPackage` | `users.users.<n>.packages += finalPackage` |
+| `home-manager.nix` | `home.packages += finalPackage` | n/a (standalone = one user) |
+
+The system+per-user logic is identical between NixOS and nix-darwin, so both
+live in `modules/my/system-scope.nix`; `nixos.nix` and `nix-darwin.nix` are thin
+imports (kept as separate files per the requested layout, and to host any future
+platform-specific divergence).
+
+**Precedence requirement:** a per-user wrapper must shadow the system one. On
+NixOS, `users.users.<n>.packages` populate `/etc/profiles/per-user/<n>`, which
+precedes `/run/current-system/sw` in the session `PATH` (via `NIX_PROFILES`
+ordering) — so the per-user wrapper wins. This is the load-bearing assumption of
+the cascade and is asserted by a dedicated VM test (`override-precedence`).
+
+## nvf via `neovimConfiguration` specialArg
+
+nvf bakes its entire config into the neovim derivation and needs a
+channel-matched builder (`nvf-darwin` / `nvf-nixos` / `nvf-nixos-unstable`).
+
+- The `neovimConfiguration` **module option is removed**. The nvf program def's
+  `build` reads `specialArgs.neovimConfiguration` — which reaches the submodule
+  because the `my` submodule type is built with `submoduleWith { specialArgs }`
+  (C2 fix). The **assertion** for a missing specialArg fires from the top-level
+  platform module (which owns specialArgs), guarded so it only triggers when nvf
+  is enabled (no eval error when disabled — S5):
+
+  ```nix
+  assertions = [{
+    assertion = !config.my.nvf.enable || (specialArgs ? neovimConfiguration);
+    message = ''my.nvf.enable requires the `neovimConfiguration` specialArg.
+      Set it where the config is built:
+        specialArgs.neovimConfiguration = inputs.nvf-<channel>.lib.neovimConfiguration;'';
+  }];
+  ```
+
+- The specialArg is set per-configuration in each partition's `default.nix`
+  (today it's a `programs.nvf.neovimConfiguration` **module option** set in
+  **host** files — `hosts/{thebeast,brutus,litus}/nvf.nix`,
+  `modules/darwin/programs/nvf.nix` — and the nvf inputs live in per-partition
+  `flake.nix`, not root). The move edits each `nixosSystem`/`mkHost` call:
+  - `modules/flake/darwin/default.nix` → `inputs.nvf-darwin...` (darwin uses one
+    shared specialArgs for **both** macs — fine, both use `nvf-darwin`).
+  - `modules/flake/nixos/default.nix` → per-host specialArgs:
+    `inputs.nvf-nixos...` (stable hosts), `inputs.nvf-nixos-unstable...`
+    (unstable host `thebeast`). The stable/unstable split must be preserved.
+  - `modules/flake/home/default.nix` → `inputs.nvf-nixos...`
+- `my.nvf` keeps its `meta` (fb meta.nvim plugin) and `settings` (deferredModule)
+  options. `finalPackage` is the built wrapped neovim, installed via the standard
+  surfaces (default system scope; per-user override allowed).
+
+## fish & direnv (no longer native exceptions)
+
+Both become ordinary package programs with baked config — there is **no system
+fish module**. The review (C3) confirmed this is feasible but is more than "bake
+`interactiveShellInit`": the wrapper must reproduce the vendor-path machinery the
+system module used to provide. Concretely the wrapped fish bakes:
+
+- a config dir it points at (`XDG_CONFIG_HOME` / `$__fish_config_dir`) holding
+  `config.fish` + `conf.d/*` carrying the init hooks HM used to emit (starship
+  init, `direnv hook fish`, carapace completer, vivid `LS_COLORS`), and
+- `XDG_DATA_DIRS` (and/or `fish_complete_path` / `fish_function_path`) extended
+  to the plugin packages' `share/fish/vendor_{completions,functions,conf}.d` so
+  `plugin-git`, carapace completions, etc. resolve **per-user** without a system
+  profile contributing them.
+
+`direnv` (`my.direnv`) wraps direnv with a baked `direnvrc` (sourcing nix-direnv)
+/ `direnv.toml`. The `direnv hook fish` line lives in the fish wrapper's baked
+`conf.d`; direnv must be installed in the same environment.
+
+**Deferred (genuinely system config, out of `my.*`):** making the wrapped fish
+the user's actual **login/interactive shell** — `/etc/shells` registration and
+`users.users.<n>.shell` — is NOT set by `my.*`. So `my.fish` yields a fully
+configured fish on `PATH` (correct prompt/completions/hooks when invoked), but it
+becomes the *default* shell only once that separate system wiring lands (a later
+refactor). This is the accepted trade-off (chosen explicitly).
+
+Standalone-HM hosts (devserver, fedora) still get login-shell wiring via HM until
+their cutover (#39); `my.fish`/`my.direnv` give them the configured package via
+`home.packages`.
+
+## fd / rg
+
+Trivial package programs: no wrapper, `build = { cfg, ... }: cfg.package`. They
+exist to bring fd/rg under the uniform `my.<tool>` enable/install surface.
+
+**Behavior change to call out (S3):** today `modules/programs/fd.nix` /`rg.nix`
+do `environment.systemPackages = [pkgs.fd]` unconditionally. Moving to
+`my.fd.enable` makes them **opt-in/enable-gated**, so the migration must set
+`my.fd.enable`/`my.rg.enable` (system scope) on every host that has them today,
+or they silently disappear.
+
+## Stylix integration (automatic, per-package target)
+
+Rather than hand-writing one target per app (`modules/stylix/users/ghostty.nix`),
+theming is a **framework feature**: a single per-package target applied to every
+`my.<tool>`, auto-enabled when stylix is defined — mirroring how upstream stylix
+auto-enables its targets.
+
+- A program def *optionally* declares a **theme mapper**:
+
+  ```nix
+  # in a program def, e.g. ghostty
+  stylix = { theme }: {            # theme = resolved base16 colors/fonts/polarity/opacity
+    background = "#${theme.base00}";
+    foreground = "#${theme.base05}";
+    palette = [ "0=#${theme.base00}" ... ];
+  };                                # -> a `settings` fragment for this tool
+  ```
+
+  Tools with no `stylix` attr are simply not themed.
+
+- The framework wires one target per package: when the integration is on for a
+  tool, it merges `stylix { theme }` into that tool's `settings` via **per-leaf
+  `lib.mkDefault`** (so the user's explicit `settings` still win — same mechanic
+  as the cascade, and what `ghostty.nix:49` does today).
+
+- `theme` is the resolved stylix theme, sourced from the system stylix config
+  (`config.lib.stylix.colors`, `config.stylix.{polarity,fonts,opacity}`) with the
+  existing per-user override surface (`modules/stylix/users/options.nix`, kept).
+  Guarded with `or` fallbacks so importing onto a host with no system stylix is a
+  no-op, not an eval error.
+
+- **Toggles:**
+  - Global: `my.stylix.enable` — the whole `my.* ↔ stylix` integration. Defaults
+    to whether stylix is defined/enabled on the host.
+  - Per-package: `my.<tool>.stylix.enable` — defaults to
+    `my.stylix.enable && my.<tool>.enable`. Lets you theme everything but opt one
+    tool out (or vice-versa).
+
+This replaces the bespoke `modules/stylix/users/ghostty.nix` target; the
+per-user stylix *foundation* (`modules/stylix/users/options.nix`, the
+colors/polarity/fonts override surface) stays and feeds `theme`.
+
+## Values migration
+
+`modules/users/jasonbk/programs/*.nix` (which set
+`users.users.jasonbk.programs.<tool>`) move to `modules/my/values/jasonbk.nix`
+setting `users.users.jasonbk.my.<tool>` — same per-user scope, new namespace.
+Standalone-HM hosts set the equivalent `my.<tool>` (system = single user) in
+their host config.
+
+## Flake wiring
+
+- `modules/default.nix` drops `./programs` and `./stylix/users`-as-is; the new
+  tree is wired by having each platform partition import the matching platform
+  module:
+  - darwin configs import `modules/my/nix-darwin.nix` (+ `values/jasonbk.nix`).
+  - nixos configs import `modules/my/nixos.nix` (+ `values/jasonbk.nix`).
+  - standalone home configs import `modules/my/home-manager.nix`.
+- The nvf `specialArgs.neovimConfiguration` is set per-configuration in each
+  partition's `default.nix`.
+- Stylix theming is wired generically by the framework (see "Stylix
+  integration"); `modules/stylix/users/ghostty.nix` is removed in favor of
+  ghostty's in-def `stylix` theme mapper, while `modules/stylix/users/options.nix`
+  (the per-user override foundation) is kept and feeds the resolved `theme`.
+
+## Deletions (scope: move + rewire + delete)
+
+- `modules/programs/` (all migrated tools) → replaced by `modules/my/programs/`.
+- `modules/users/` → replaced by `modules/my/values/`.
+- Legacy duplicates: `modules/darwin/programs/git.nix`, `.../nvf.nix`,
+  `modules/home-manager/jasonbk/programs/{git,jujutsu,...}` for migrated tools.
+- `modules/programs/tests/` → `modules/my/tests/`.
+
+Remaining host-by-host HM removal for not-yet-migrated tools stays as the open
+issues (#43–#57).
+
+**Darwin per-user is ready now (supersedes stale `WRAPPERS.md`):** review (S4)
+verified nix-darwin **does** support `users.users.<n>.packages`
+(`/etc/profiles/per-user/<name>`), and that per-user wrappers shadow system ones
+in PATH on **both** NixOS (`mkAfter` on `/run/current-system/sw`) and nix-darwin
+(`mkOrder 900` on the per-user profile). So `WRAPPERS.md`'s "darwin's
+`users.users` has no packages yet — cutover later" note is obsolete and this
+design installs darwin per-user wrappers directly; `WRAPPERS.md` is rewritten to
+the `my.*` convention. Darwin's `users.knownUsers`/`uid` requirements still
+apply.
+
+## Testing
+
+`modules/my/tests/*.nix` are `{pkgs, inputs ? null}` -> VM test, auto-registered
+(check name = file name), merged into `perSystem.checks`. Assert **plumbing**,
+not real defaults (repo rule):
+
+- `<tool>-wrapper`: sentinel through `settings` -> read back via the wrapped
+  binary (ports the existing `jujutsu/git/gh/ghostty-stylix` tests).
+- `override-precedence` (new, load-bearing): system `my.git` + a user with
+  `users.users.<n>.my.git.enable` and a distinct sentinel; assert the user's
+  shell resolves the per-user wrapper (per-user shadows system) and that
+  cascade deep-merge produced system+user settings.
+- `nvf-specialarg` (new): assert a clear eval error when `my.nvf.enable` and no
+  `neovimConfiguration` specialArg; and a successful build when provided.
+
+## Execution
+
+1. **Foundation (serial):** `lib.nix`, `system-scope.nix`, the 3 platform
+   modules, tests harness; migrate **jujutsu** as the reference; wire one host;
+   `nix flake check` + a representative build green.
+2. **Fan-out (parallel, frozen contract):** git, gh, starship, nushell, ghostty
+   (+ stylix target retarget), nvf (specialArg + per-channel partition wiring),
+   fish, direnv, fd/rg; `values/jasonbk.nix`; host rewiring + old-module
+   deletion.
+3. **Workstream B (parallel, independent):** rewrite issue #36 and the linked
+   unfinished issues to the `my.*` convention.
+
+[#36]: https://github.com/jasonboukheir/dotfiles/issues/36
+[#39]: https://github.com/jasonboukheir/dotfiles/issues/39

--- a/docs/plans/2026-06-09-my-namespace-wrappers-design.md
+++ b/docs/plans/2026-06-09-my-namespace-wrappers-design.md
@@ -1,0 +1,362 @@
+# Design: `my.*` namespace for wrapped programs
+
+Migrating off home-manager (epic [#36]) introduced per-user hand-rolled wrappers
+under `programs.<tool>` / `users.users.<name>.programs.<tool>`. This design
+reorganizes that into a dedicated `my.*` namespace with explicit
+system-vs-per-user semantics, a single program-definition contract, and three
+platform consumers, all under `modules/my/`.
+
+## Goals
+
+- `my.<tool>.enable` installs a configured (wrapped) package **system-wide** (all
+  users).
+- `users.users.<name>.my.<tool>.enable` installs it **for one user**, whose
+  config **cascades from** and **deep-merges over** the system config, and whose
+  wrapper **shadows** the system one in that user's PATH.
+- One reorganized tree, `modules/my/`, with three platform modules
+  (`nixos.nix`, `nix-darwin.nix`, `home-manager.nix`) consuming one set of
+  program definitions.
+- `my.*` is **only** "configure a package and install it in the right
+  environment." It never sets system state (shell registration, login shell,
+  services). Those stay on normal NixOS/darwin options, out of scope here.
+
+## Why `my.*`
+
+Short, collision-free with upstream `programs.*` (which carries hundreds of
+NixOS/HM options). The current scheme overloads `programs.*`, which both risks
+collisions and conflates "native upstream module" with "our wrapper." A private
+prefix cleanly separates our surface.
+
+## Directory layout
+
+```
+modules/my/
+  lib.nix              # framework: builds the option tree + cascade + install
+  programs/
+    default.nix        # collects all program defs into an attrset
+    git.nix  jujutsu.nix  gh.nix  starship.nix  ghostty.nix
+    fish.nix  direnv.nix  nvf/  fd.nix  rg.nix  nushell/
+  system-scope.nix     # shared system+per-user core for nixos & nix-darwin
+  nixos.nix            # thin: imports system-scope, installs into NixOS surfaces
+  nix-darwin.nix       # thin: imports system-scope, installs into darwin surfaces
+  home-manager.nix     # standalone-HM: my.<tool> (single user) -> home.packages
+  values/
+    jasonbk.nix        # jasonbk's per-user values (users.users.jasonbk.my.*)
+  tests/
+    default.nix        # auto-registers every *.nix as a flake check
+    <tool>-wrapper.nix # plumbing assertions per tool
+```
+
+`pkgs.mkWrapped` (`modules/nixpkgs/overlays/mkWrapped.nix`) stays as-is — the
+build primitive every package program uses.
+
+## The program-definition contract
+
+Every `modules/my/programs/<tool>.nix` is a function returning **one shape**:
+
+```nix
+{ lib, pkgs }: {
+  name = "jujutsu";              # key under my.<name> / users.users.<n>.my.<name>
+  defaultPackage = "jujutsu";    # attr name into pkgs for mkPackageOption
+  options = {                    # tool-specific options ONLY (freeform/scalars)
+    settings = lib.mkOption {
+      type = (pkgs.formats.toml {}).type;
+      default = {};
+      description = "Baked into this jj wrapper via JJ_CONFIG.";
+    };
+  };
+  build = { cfg, specialArgs }: pkgs.mkWrapped {   # resolved cfg -> installed pkg
+    pkg = cfg.package;
+    name = "jj";
+    env.JJ_CONFIG = (pkgs.formats.toml {}).generate "jj-config.toml" cfg.settings;
+  };
+}
+```
+
+`lib.nix` injects the **universal** options into every tool, so tool files never
+declare them:
+
+- `enable` — `mkEnableOption`.
+- `package` — `mkPackageOption pkgs defaultPackage {}`.
+- `finalPackage` — read-only, `= build { cfg = <this scope's resolved cfg>; inherit specialArgs; }`.
+
+There is no `native`/`system`/`user`/`userUnsupported` distinction: tools that
+used to rely on system-level shell integration (fish, direnv) bake that
+integration into their wrapper instead (see "fish & direnv" below).
+
+`build` receives `specialArgs` so nvf can read `neovimConfiguration` (see "nvf").
+
+## Option scopes & cascade
+
+`lib.nix` defines **one** shared submodule type from the program defs (the
+`my.<tool>` surface: `enable`/`package`/`finalPackage` + each tool's options) and
+uses it for **both** scopes — no two parallel option trees to keep in sync. It is
+built with `lib.types.submoduleWith { specialArgs = { … }; modules = [ … ]; }` so
+the submodule receives `neovimConfiguration` (plain `submodule`s do **not**
+inherit the parent `nixosSystem`/`darwinSystem` `specialArgs` — verified in
+review, C2).
+
+**System scope** — declared by every platform module:
+
+```nix
+options.my = mkOption { type = myProgramsSubmodule; default = {}; };
+# -> config.my.<tool>.{enable,package,finalPackage,...}
+```
+
+**Per-user scope** — declared by `nixos.nix`/`nix-darwin.nix` only, by
+module-merging the same submodule type onto `users.users.<name>`:
+
+```nix
+options.users.users = mkOption {
+  type = attrsOf (submodule { options.my = mkOption { type = myProgramsSubmodule; default = {}; }; });
+};
+```
+
+**Cascade rules** — implemented in the platform module (which *does* receive
+specialArgs and the top-level `config`) by pushing the system config into each
+user's `my` as **per-leaf** `mkDefault` definitions:
+
+- `enable` defaults to **`false`** (explicit per-user opt-in). A system-enabled
+  tool therefore does **not** redundantly fan a per-user copy into every user
+  profile; users opt in only to override.
+- For every **other** option, the cascade recurses the system value and wraps
+  **each leaf** in `lib.mkDefault` (a `mapAttrsRecursive`-style walk), then sets
+  that as a config definition on `users.users.<n>.my.<tool>`:
+
+  ```nix
+  # per user, per tool, in the platform module:
+  users.users.<n>.my.<tool> = recursiveMkDefault (removeAttrs config.my.<tool> ["enable" "finalPackage"]);
+  ```
+
+  This is the **load-bearing mechanic** and the one the review proved must be
+  per-leaf: a whole-attrset `mkDefault` is a single low-priority definition that
+  the module system drops entirely once the user sets the option, silently
+  losing all system keys. Per-leaf `mkDefault` instead **deep-merges** nested
+  keys with the user's explicit settings while letting the user **win on
+  scalars** (verified empirically). List leaves are replaced, not concatenated
+  (intended). This is exactly the pattern `modules/stylix/users/ghostty.nix:49`
+  (`lib.mapAttrs (_: lib.mkDefault) themed`) already uses for its target.
+
+Example:
+
+```nix
+my.git.settings.init.defaultBranch = "main";                # system
+users.users.alice.my.git = {                                # alice opts in
+  enable = true;
+  settings.user.email = "a@x";                              # merges over system
+};
+# alice's wrapper: { init.defaultBranch="main"; user.email="a@x"; }
+# bob: no per-user entry -> uses the system wrapper unchanged
+```
+
+## Installation surfaces & PATH precedence
+
+| Module | `my.<tool>.enable` | `users.users.<n>.my.<tool>.enable` |
+|---|---|---|
+| `nixos.nix` | `environment.systemPackages += finalPackage` | `users.users.<n>.packages += finalPackage` |
+| `nix-darwin.nix` | `environment.systemPackages += finalPackage` | `users.users.<n>.packages += finalPackage` |
+| `home-manager.nix` | `home.packages += finalPackage` | n/a (standalone = one user) |
+
+The system+per-user logic is identical between NixOS and nix-darwin, so both
+live in `modules/my/system-scope.nix`; `nixos.nix` and `nix-darwin.nix` are thin
+imports (kept as separate files per the requested layout, and to host any future
+platform-specific divergence).
+
+**Precedence requirement:** a per-user wrapper must shadow the system one. On
+NixOS, `users.users.<n>.packages` populate `/etc/profiles/per-user/<n>`, which
+precedes `/run/current-system/sw` in the session `PATH` (via `NIX_PROFILES`
+ordering) — so the per-user wrapper wins. This is the load-bearing assumption of
+the cascade and is asserted by a dedicated VM test (`override-precedence`).
+
+## nvf via `neovimConfiguration` specialArg
+
+nvf bakes its entire config into the neovim derivation and needs a
+channel-matched builder (`nvf-darwin` / `nvf-nixos` / `nvf-nixos-unstable`).
+
+- The `neovimConfiguration` **module option is removed**. The nvf program def's
+  `build` reads `specialArgs.neovimConfiguration` — which reaches the submodule
+  because the `my` submodule type is built with `submoduleWith { specialArgs }`
+  (C2 fix). The **assertion** for a missing specialArg fires from the top-level
+  platform module (which owns specialArgs), guarded so it only triggers when nvf
+  is enabled (no eval error when disabled — S5):
+
+  ```nix
+  assertions = [{
+    assertion = !config.my.nvf.enable || (specialArgs ? neovimConfiguration);
+    message = ''my.nvf.enable requires the `neovimConfiguration` specialArg.
+      Set it where the config is built:
+        specialArgs.neovimConfiguration = inputs.nvf-<channel>.lib.neovimConfiguration;'';
+  }];
+  ```
+
+- The specialArg is set per-configuration in each partition's `default.nix`
+  (today it's a `programs.nvf.neovimConfiguration` **module option** set in
+  **host** files — `hosts/{thebeast,brutus,litus}/nvf.nix`,
+  `modules/darwin/programs/nvf.nix` — and the nvf inputs live in per-partition
+  `flake.nix`, not root). The move edits each `nixosSystem`/`mkHost` call:
+  - `modules/flake/darwin/default.nix` → `inputs.nvf-darwin...` (darwin uses one
+    shared specialArgs for **both** macs — fine, both use `nvf-darwin`).
+  - `modules/flake/nixos/default.nix` → per-host specialArgs:
+    `inputs.nvf-nixos...` (stable hosts), `inputs.nvf-nixos-unstable...`
+    (unstable host `thebeast`). The stable/unstable split must be preserved.
+  - `modules/flake/home/default.nix` → `inputs.nvf-nixos...`
+- `my.nvf` keeps its `meta` (fb meta.nvim plugin) and `settings` (deferredModule)
+  options. `finalPackage` is the built wrapped neovim, installed via the standard
+  surfaces (default system scope; per-user override allowed).
+
+## fish & direnv (no longer native exceptions)
+
+Both become ordinary package programs with baked config — there is **no system
+fish module**. The review (C3) confirmed this is feasible but is more than "bake
+`interactiveShellInit`": the wrapper must reproduce the vendor-path machinery the
+system module used to provide. Concretely the wrapped fish bakes:
+
+- a config dir it points at (`XDG_CONFIG_HOME` / `$__fish_config_dir`) holding
+  `config.fish` + `conf.d/*` carrying the init hooks HM used to emit (starship
+  init, `direnv hook fish`, carapace completer, vivid `LS_COLORS`), and
+- `XDG_DATA_DIRS` (and/or `fish_complete_path` / `fish_function_path`) extended
+  to the plugin packages' `share/fish/vendor_{completions,functions,conf}.d` so
+  `plugin-git`, carapace completions, etc. resolve **per-user** without a system
+  profile contributing them.
+
+`direnv` (`my.direnv`) wraps direnv with a baked `direnvrc` (sourcing nix-direnv)
+/ `direnv.toml`. The `direnv hook fish` line lives in the fish wrapper's baked
+`conf.d`; direnv must be installed in the same environment.
+
+**Deferred (genuinely system config, out of `my.*`):** making the wrapped fish
+the user's actual **login/interactive shell** — `/etc/shells` registration and
+`users.users.<n>.shell` — is NOT set by `my.*`. So `my.fish` yields a fully
+configured fish on `PATH` (correct prompt/completions/hooks when invoked), but it
+becomes the *default* shell only once that separate system wiring lands (a later
+refactor). This is the accepted trade-off (chosen explicitly).
+
+Standalone-HM hosts (devserver, fedora) still get login-shell wiring via HM until
+their cutover (#39); `my.fish`/`my.direnv` give them the configured package via
+`home.packages`.
+
+## fd / rg
+
+Trivial package programs: no wrapper, `build = { cfg, ... }: cfg.package`. They
+exist to bring fd/rg under the uniform `my.<tool>` enable/install surface.
+
+**Behavior change to call out (S3):** today `modules/programs/fd.nix` /`rg.nix`
+do `environment.systemPackages = [pkgs.fd]` unconditionally. Moving to
+`my.fd.enable` makes them **opt-in/enable-gated**, so the migration must set
+`my.fd.enable`/`my.rg.enable` (system scope) on every host that has them today,
+or they silently disappear.
+
+## Stylix integration (automatic, per-package target)
+
+Rather than hand-writing one target per app (`modules/stylix/users/ghostty.nix`),
+theming is a **framework feature**: a single per-package target applied to every
+`my.<tool>`, auto-enabled when stylix is defined — mirroring how upstream stylix
+auto-enables its targets.
+
+- A program def *optionally* declares a **theme mapper**:
+
+  ```nix
+  # in a program def, e.g. ghostty
+  stylix = { theme }: {            # theme = resolved base16 colors/fonts/polarity/opacity
+    background = "#${theme.base00}";
+    foreground = "#${theme.base05}";
+    palette = [ "0=#${theme.base00}" ... ];
+  };                                # -> a `settings` fragment for this tool
+  ```
+
+  Tools with no `stylix` attr are simply not themed.
+
+- The framework wires one target per package: when the integration is on for a
+  tool, it merges `stylix { theme }` into that tool's `settings` via **per-leaf
+  `lib.mkDefault`** (so the user's explicit `settings` still win — same mechanic
+  as the cascade, and what `ghostty.nix:49` does today).
+
+- `theme` is the resolved stylix theme, sourced from the system stylix config
+  (`config.lib.stylix.colors`, `config.stylix.{polarity,fonts,opacity}`) with the
+  existing per-user override surface (`modules/stylix/users/options.nix`, kept).
+  Guarded with `or` fallbacks so importing onto a host with no system stylix is a
+  no-op, not an eval error.
+
+- **Toggles:**
+  - Global: `my.stylix.enable` — the whole `my.* ↔ stylix` integration. Defaults
+    to whether stylix is defined/enabled on the host.
+  - Per-package: `my.<tool>.stylix.enable` — defaults to
+    `my.stylix.enable && my.<tool>.enable`. Lets you theme everything but opt one
+    tool out (or vice-versa).
+
+This replaces the bespoke `modules/stylix/users/ghostty.nix` target; the
+per-user stylix *foundation* (`modules/stylix/users/options.nix`, the
+colors/polarity/fonts override surface) stays and feeds `theme`.
+
+## Values migration
+
+`modules/users/jasonbk/programs/*.nix` (which set
+`users.users.jasonbk.programs.<tool>`) move to `modules/my/values/jasonbk.nix`
+setting `users.users.jasonbk.my.<tool>` — same per-user scope, new namespace.
+Standalone-HM hosts set the equivalent `my.<tool>` (system = single user) in
+their host config.
+
+## Flake wiring
+
+- `modules/default.nix` drops `./programs` and `./stylix/users`-as-is; the new
+  tree is wired by having each platform partition import the matching platform
+  module:
+  - darwin configs import `modules/my/nix-darwin.nix` (+ `values/jasonbk.nix`).
+  - nixos configs import `modules/my/nixos.nix` (+ `values/jasonbk.nix`).
+  - standalone home configs import `modules/my/home-manager.nix`.
+- The nvf `specialArgs.neovimConfiguration` is set per-configuration in each
+  partition's `default.nix`.
+- Stylix theming is wired generically by the framework (see "Stylix
+  integration"); `modules/stylix/users/ghostty.nix` is removed in favor of
+  ghostty's in-def `stylix` theme mapper, while `modules/stylix/users/options.nix`
+  (the per-user override foundation) is kept and feeds the resolved `theme`.
+
+## Deletions (scope: move + rewire + delete)
+
+- `modules/programs/` (all migrated tools) → replaced by `modules/my/programs/`.
+- `modules/users/` → replaced by `modules/my/values/`.
+- Legacy duplicates: `modules/darwin/programs/git.nix`, `.../nvf.nix`,
+  `modules/home-manager/jasonbk/programs/{git,jujutsu,...}` for migrated tools.
+- `modules/programs/tests/` → `modules/my/tests/`.
+
+Remaining host-by-host HM removal for not-yet-migrated tools stays as the open
+issues (#43–#57).
+
+**Darwin per-user is ready now (supersedes stale `WRAPPERS.md`):** review (S4)
+verified nix-darwin **does** support `users.users.<n>.packages`
+(`/etc/profiles/per-user/<name>`), and that per-user wrappers shadow system ones
+in PATH on **both** NixOS (`mkAfter` on `/run/current-system/sw`) and nix-darwin
+(`mkOrder 900` on the per-user profile). So `WRAPPERS.md`'s "darwin's
+`users.users` has no packages yet — cutover later" note is obsolete and this
+design installs darwin per-user wrappers directly; `WRAPPERS.md` is rewritten to
+the `my.*` convention. Darwin's `users.knownUsers`/`uid` requirements still
+apply.
+
+## Testing
+
+`modules/my/tests/*.nix` are `{pkgs, inputs ? null}` -> VM test, auto-registered
+(check name = file name), merged into `perSystem.checks`. Assert **plumbing**,
+not real defaults (repo rule):
+
+- `<tool>-wrapper`: sentinel through `settings` -> read back via the wrapped
+  binary (ports the existing `jujutsu/git/gh/ghostty-stylix` tests).
+- `override-precedence` (new, load-bearing): system `my.git` + a user with
+  `users.users.<n>.my.git.enable` and a distinct sentinel; assert the user's
+  shell resolves the per-user wrapper (per-user shadows system) and that
+  cascade deep-merge produced system+user settings.
+- `nvf-specialarg` (new): assert a clear eval error when `my.nvf.enable` and no
+  `neovimConfiguration` specialArg; and a successful build when provided.
+
+## Execution
+
+1. **Foundation (serial):** `lib.nix`, `system-scope.nix`, the 3 platform
+   modules, tests harness; migrate **jujutsu** as the reference; wire one host;
+   `nix flake check` + a representative build green.
+2. **Fan-out (parallel, frozen contract):** git, gh, starship, nushell, ghostty
+   (+ stylix target retarget), nvf (specialArg + per-channel partition wiring),
+   fish, direnv, fd/rg; `values/jasonbk.nix`; host rewiring + old-module
+   deletion.
+3. **Workstream B (parallel, independent):** rewrite issue #36 and the linked
+   unfinished issues to the `my.*` convention.
+
+[#36]: https://github.com/jasonboukheir/dotfiles/issues/36
+[#39]: https://github.com/jasonboukheir/dotfiles/issues/39

--- a/docs/plans/my-namespace-wrappers-design-review-1.md
+++ b/docs/plans/my-namespace-wrappers-design-review-1.md
@@ -1,0 +1,90 @@
+VERDICT: NEEDS_REVISION
+
+## Summary Assessment
+
+The reorganization (`modules/my/`, single program-def contract, thin platform consumers) is sound and the PATH-precedence claim holds on **both** NixOS and nix-darwin, but the design's central cascade mechanic — "inject the system value as a whole-attrset `mkDefault` to get deep-merge" — is **provably wrong** (it defeats deep-merge exactly like `default =` does), and the nvf `specialArgs` plumbing cannot work where the design places it because plain `submodule`s do not receive the parent's `specialArgs`.
+
+## Critical Issues (must fix)
+
+### C1. The cascade deep-merge claim is false as specified (whole-attrset `mkDefault`)
+
+Design lines 122-124 state the per-user submodule injects the system value as `lib.mkDefault config.my.<tool>.<opt>` and asserts: *"Because freeform `formats.*` / `attrsOf` options merge across definitions, the user's explicit settings deep-merge over the inherited system settings… Pure option `default =` would replace whole attrsets, defeating deep-merge — hence `mkDefault` definitions, not defaults."*
+
+This reasoning is backwards. I verified empirically against the repo's own nixpkgs (`pkgs.formats.toml {}` type, three-module `evalModules`):
+
+- **Whole-attrset `mkDefault` (what the design specifies):**
+  system `mkDefault { init.defaultBranch="main"; user.name="sys"; }` + user `{ user.email="a@x"; }`
+  → result `{ user = { email = "a@x"; }; }`. **The system's `init.defaultBranch` and `user.name` are silently lost.**
+
+  A `mkDefault` whole-attrset is a *single lower-priority definition*; the module system's priority filter drops it entirely the moment a higher-priority (normal) definition of the same option exists. Deep-merge across definitions only happens between definitions of **equal** priority. So whole-attrset `mkDefault` has the *exact* defeating-deep-merge problem the design ascribes to `default =`.
+
+- **Equal-priority injection** (`config.settings = systemValue;` with no `mkDefault`): deep-merges correctly (`{ init.defaultBranch="main"; user={email="a@x"; name="sys"}; }`) — **but** if the user sets a scalar the system also set (e.g. both set `ui.editor`), evaluation **fails** with a conflicting-definition error. This breaks the design's own promise (line 124) that "scalars are replaced" by the user.
+
+- **Per-leaf recursive `mkDefault`** (recurse into the system attrset and wrap each *leaf* in `mkDefault`): the only approach that gives **both** deep-merge of nested keys **and** user-wins-on-scalars. Verified: `{ init.defaultBranch="main"; user={email="a@x"; name="sys"}; }` with user override of a leaf succeeding.
+
+**Required fix:** the cascade must recurse the system config and apply `mkDefault` per leaf (a `mapAttrsRecursive`-style wrap), not `mkDefault` the whole attrset. This is non-trivial for freeform types because the framework must walk arbitrary `formats.*` attrsets (and handle lists — a `mkDefault`'d list leaf is *replaced*, not concatenated, which is probably the desired behavior but should be stated). The design should specify this algorithm explicitly; it is the load-bearing mechanic and the current spec produces silently-wrong wrappers.
+
+### C2. `specialArgs` are not available inside the per-user submodule where `build`/`finalPackage` run
+
+Design lines 68, 81-87 define `build = { cfg, specialArgs }: …` and `finalPackage = build { cfg = <this scope's cfg>; inherit specialArgs; }`, computed inside the per-user submodule (and the system scope). I verified that a plain `lib.types.submodule` calls `evalModules` with `specialArgs ? {}` defaulted to empty (`lib/types.nix` `submoduleWith`, ~line 1437) — the parent `nixosSystem`/`darwinSystem` `specialArgs` (where `inputs`/`neovimConfiguration` live) are **not** propagated into `users.users.<name>` submodules. A submodule that takes `{ specialArgs, … }` or `{ neovimConfiguration, … }` as a module arg throws `attribute … missing`.
+
+Two consequences:
+- nvf as a **per-user** wrapper cannot read `specialArgs.neovimConfiguration` at all under the proposed shape.
+- Even at **system scope**, `finalPackage` computed *inside an option declaration* (`finalPackage = build {…specialArgs}`) only works if the framework explicitly threads `specialArgs` into the module that declares the option. System-scope modules do receive specialArgs (top-level), so this is salvageable there; the per-user submodule is not.
+
+**Required fix:** either (a) declare the per-user surface with `submoduleWith { specialArgs = { inherit neovimConfiguration …; }; }` so the submodule receives them, or (b) have the *top-level* platform module (which does get specialArgs) read `neovimConfiguration` and inject it into each user submodule's config via `_module.args`, or (c) keep nvf out of the per-user scope entirely and special-case it as system-only. The design must pick one; as written, `build { … specialArgs }` inside the submodule is an eval error. (I confirmed the top-level-reads-then-injects pattern works.)
+
+### C3. fish cannot be a pure per-user wrapper — real system-level support is required
+
+The design (lines 179-196) claims fish's `interactiveShellInit`, completions, `plugin-git`, starship init, carapace, vivid `LS_COLORS`, and `direnv hook fish` all "bake into a config dir the wrapped fish points at" with shell registration merely "out of scope." Reading the upstream NixOS fish module (`nixpkgs/nixos/modules/programs/fish.nix`) shows this hand-waves a genuine gap:
+
+- fish only auto-sources `/etc/fish/config.fish` and the generated `shellInit`/`loginShellInit`/`interactiveShellInit` **when fish is the login/interactive shell**. A wrapped fish binary on `PATH` invoked as `fish` still reads `$__fish_config_dir`/`/etc/fish`, but the *system* `interactiveShellInit` (starship init etc.) lives in `/etc/fish/interactiveShellInit.fish` generated by the system module — not in the wrapper. The current repo (`modules/programs/fish.nix`) deliberately puts `starship init fish` into `programs.fish.interactiveShellInit` at **system** scope precisely because that is where fish sources it.
+- The module generates system completions into `/etc/fish/generated_completions` (a `buildEnv` over all `systemPackages`) and links vendor dirs via `pathsToLink` (`vendor_conf.d`/`vendor_completions.d`/`vendor_functions.d`). `plugin-git`'s functions ride in via the *system profile's* `share/fish/vendor_functions.d` — the current `fish.nix` installs it to `environment.systemPackages` for exactly that reason. Pointing a wrapper's `$__fish_config_dir` elsewhere does not reproduce the vendor-path machinery; you would have to re-implement `fish_complete_path`/`fish_function_path` assembly inside the wrapper.
+- The module appends fish to `environment.shells` (→ `/etc/shells`) and that, plus `users.users.<n>.shell`, is what makes fish a usable login shell. The design correctly scopes these out — but combined with the above, "`my.fish` only configures+installs the package" leaves the *interactive experience* (prompt, completions, hooks) dependent on system state that `my.*` refuses to set. That is not merely "shell registration out of scope"; it's the core feature set.
+
+`direnv` is genuinely simpler — a baked `direnvrc`/`direnv.toml` plus the `direnv hook fish` line living in fish's init is plausible — but it inherits fish's problem: the hook only runs if fish actually sources the wrapper's init.
+
+**Required fix:** the design should either (a) explicitly keep a thin system-level fish integration module (`/etc/fish` init + vendor `pathsToLink` + completion generation) outside `my.*` and have `my.fish` only own the *config content* it feeds in, or (b) drop the claim that fish/direnv become "ordinary package programs with NO system support" and document precisely which system hooks remain. As written, a per-user `my.fish` wrapper with no system module yields a fish with no prompt, no vendor completions, and no plugin-git for any user who is not also covered by the (now-deleted) system fish module.
+
+### C4. The design misrepresents the stylix precedent it leans on
+
+Design lines 102-103 and 124 cite `modules/stylix/users/` as the precedent for the cascade and imply it injects system values as config-level `mkDefault` definitions. It does not. `modules/stylix/users/options.nix` reads the **top-level** `config.stylix.*` / `config.lib.stylix.colors` (the perUser submodule closes over the outer module's `config`) and uses them as **`default =`** values on each per-user option (lines 27-103), guarded with `or` fallbacks. The only `mkDefault` use is in the *target* (`ghostty.nix` line 49: `lib.mapAttrs (_: lib.mkDefault) themed`) which writes **per-leaf** `mkDefault` into the wrapper's `settings` — i.e. precisely the per-leaf approach C1 says the cascade needs, **not** a whole-attrset mkDefault.
+
+So the precedent actually contradicts the design's stated mechanic and supports the C1 fix. The design should be rewritten to match what stylix really does (top-level `config` read + per-leaf `mkDefault` at the target), and stop citing it as justification for whole-attrset `mkDefault`.
+
+## Suggestions (nice to have)
+
+### S1. Collapse the two option scopes into one shared submodule type
+
+The design declares the same option set twice (system scope on the platform module + per-user scope on the `users.users` submodule) and a `lib.nix` framework to keep them in sync. Given C2 already pushes you toward `submoduleWith` for the per-user surface, consider defining **one** `programModule = { lib, pkgs, specialArgs }: submoduleWith { specialArgs; modules = [ … ]; }` and using it both as the type of `users.users.<n>.my` and, for the system scope, as a single `my` submodule instance. This removes the duplication the `lib.nix` framework exists to manage and makes the cascade a single well-defined operation (merge two evaluated configs) rather than two parallel option trees.
+
+### S2. `finalPackage` as a readOnly option computed by `build` is fine — but keep `build` pure
+
+Computing `finalPackage` from sibling options in the same submodule is sound (no recursion risk: `build` reads `cfg.*` which are independent options; `finalPackage` is not read by them). The risk is only if `build` reads `config` outside its own `cfg`/`specialArgs` — keep the contract `build = { cfg, specialArgs }` strictly closed over those two and it's safe. Add this as an explicit rule.
+
+### S3. fd/rg inconsistency with current repo
+
+Design lines 203-205 make fd/rg trivial `my.<tool>` programs (`build = cfg.package`). Today `modules/programs/fd.nix` is `environment.systemPackages = [pkgs.fd]` (system-wide, not per-user). That's a behavior change (fd moves from always-system to enable-gated). Fine, but call it out in the migration notes so fd/rg don't silently disappear from hosts that don't opt in.
+
+### S4. Darwin per-user cutover is actually ready — update the stale WRAPPERS.md caveat
+
+`docs/WRAPPERS.md` (lines 62-64) says "darwin's `users.users` has no packages yet — its cutover comes later," and the per-user values are currently wired only through `modules/nixos/default.nix` (`../users`), not darwin. I verified nix-darwin **does** support `users.users.<n>.packages` (`modules/users/default.nix` builds `/etc/profiles/per-user/<name>` via `environment.etc`, lines 333-341). The design's plan to install darwin per-user wrappers there is feasible today — but the design should explicitly note it is *superseding* that WRAPPERS.md caveat, and that darwin's `users.knownUsers`/`uid` requirements (modules/darwin/users.nix) still apply.
+
+### S5. nvf assertion-when-missing must not eval-error when nvf is disabled
+
+Design lines 164-167 want a clear assertion when `my.nvf.enable && neovimConfiguration` is absent. Ensure the `neovimConfiguration` read is lazy/guarded (the current `config.nix` only touches it under `lib.mkIf cfg.enable`, which is correct). With the C2 fix, the assertion should fire from the top-level module that owns specialArgs, asserting `cfg.enable -> (specialArgs ? neovimConfiguration)`, not from inside a submodule that can't see specialArgs.
+
+### S6. nvf `neovimConfiguration` is currently set in host files, not partitions
+
+Design lines 168-174 say the flake partitions set the specialArg. Today it is set in **host** files (`hosts/{thebeast,brutus,litus}/nvf.nix`, `modules/darwin/programs/nvf.nix`) as a `programs.nvf.neovimConfiguration` *module option*, and the nvf inputs are declared per-partition `flake.nix` (`modules/flake/{nixos,home,darwin}/flake.nix`), not the root `flake.nix`. Moving to `specialArgs` requires editing each partition's `default.nix` `mkHost`/`nixosSystem` call (darwin's `mkHost` uses a shared `specialArgs` for *both* macs, which is fine since both use `nvf-darwin`; nixos sets specialArgs per-host so the unstable/stable split — `thebeast` uses `nvf-nixos-unstable`, others `nvf-nixos` — maps cleanly). Doable, but the design should name the exact files and note darwin's shared-specialArgs vs nixos's per-host-specialArgs asymmetry.
+
+## Verified Claims (confirmed correct against the code)
+
+- **PATH precedence on NixOS:** `environment.profiles` orders `/etc/profiles/per-user/$USER` before `/run/current-system/sw` (`nixpkgs/nixos/modules/config/users-groups.nix` lines 1000-1005 at normal priority; `nixos/modules/programs/environment.nix` line 28 `mkAfter`s `/run/current-system/sw`). PATH is built in profile order, so the per-user wrapper shadows the system one. **Correct.**
+- **PATH precedence on nix-darwin:** `environment.profiles` uses `mkOrder 900` for `/etc/profiles/per-user/$USER` vs default (1000) for `/run/current-system/sw` (nix-darwin `modules/users/default.nix` line 343, `modules/environment/default.nix` lines 178-187). `systemPath = [(makeBinPath cfg.profiles)]` preserves ascending order, so per-user precedes system in PATH. **Correct on darwin too** (note NIX_PROFILES is reverse-ordered, but PATH is not — the wrapper shadowing relies on PATH, which is correct).
+- **nix-darwin supports `users.users.<n>.packages`:** builds `/etc/profiles/per-user/<name>` via `environment.etc` (`modules/users/default.nix` 333-341). The design treating darwin per-user installs as working today is **correct** and supersedes the stale WRAPPERS.md note (see S4).
+- **`mkWrapped` primitive** (`modules/nixpkgs/overlays/mkWrapped.nix`) is a `symlinkJoin` + `wrapProgram --set/--prefix PATH/--add-flags`, shell-escaped, with `passthru.unwrapped`/`meta.mainProgram`. Staying as-is is fine; it supports every program-def's `build`.
+- **Single shared `modules/programs` tree** is imported by both NixOS and darwin via `modules/default.nix` (`./programs`), matching the design's `system-scope.nix` shared-between-platforms approach.
+- **Per-leaf `mkDefault` deep-merges correctly** with a user's explicit settings while letting the user win on scalars — empirically verified; this is the correct cascade mechanism the C1 fix should adopt (and what stylix's ghostty target already does).
+- **Test harness auto-registration** (`modules/programs/tests/default.nix`) maps every non-`default.nix` `*.nix` to a check named by filename and threads `{pkgs, inputs}`; `inputs` reaches the nvf tests (`nvf-polarity.nix` uses `inputs.nvf-nixos.lib.neovimConfiguration`). Moving to `modules/my/tests/` with the same harness is straightforward, and a `nvf-specialarg`/`override-precedence` test is implementable on this harness (override-precedence needs a multi-user NixOS VM asserting `su -l user2` resolves the per-user wrapper — feasible).
+- **gh's `GH_CONFIG_DIR` caveat** (design keeps only `GH_EDITOR`) matches `modules/programs/gh.nix` — auth must stay in the real config dir; the design preserves this.

--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -6,5 +6,6 @@
     ./environment.nix
     ./nix.nix
     ./users.nix
+    ../my/nix-darwin.nix
   ];
 }

--- a/modules/flake/home/default.nix
+++ b/modules/flake/home/default.nix
@@ -12,6 +12,7 @@
       };
       commonModules = [
         ../../../modules/programs/nvf/home-manager.nix
+        ../../../modules/my/home-manager.nix
         {
           programs.nvf = {
             enable = true;

--- a/modules/flake/nixos/default.nix
+++ b/modules/flake/nixos/default.nix
@@ -65,6 +65,7 @@
         in {
           checks =
             (import ../../../modules/programs/tests {inherit pkgs inputs;})
+            // (import ../../../modules/my/tests {inherit pkgs inputs;})
             // {
               thebeast-session = import ../../../hosts/thebeast/tests/session.nix {
                 inherit pkgs inputs;

--- a/modules/my/home-manager.nix
+++ b/modules/my/home-manager.nix
@@ -1,8 +1,5 @@
-# home-manager entry point for the my.* surface, for the standalone-HM hosts
-# (work-devserver, jasonbk-fedora) which have no system layer. A standalone host
-# is effectively single-user, so it exposes only the system scope (my.<tool>) and
-# installs finalPackage into home.packages. Hosts with a system layer use
-# ./nixos.nix / ./nix-darwin.nix instead.
+# home-manager entry point for my.*, for the standalone-HM hosts (no system
+# layer). Single-user: only the system scope (my.<tool>) -> home.packages.
 {
   config,
   lib,
@@ -33,9 +30,8 @@ in {
     default = {};
   };
 
-  # finalPackage is unconditional (lazy); only the install + assertions are gated
-  # on enable. See the note in ./system-scope.nix on why gating finalPackage
-  # inside the `my` submodule causes infinite recursion.
+  # finalPackage unconditional (lazy); only the install is gated. See the
+  # recursion note in ./system-scope.nix.
   config = lib.mkMerge [
     {my.stylix.enable = lib.mkDefault (systemStylix.enable or false);}
     {

--- a/modules/my/home-manager.nix
+++ b/modules/my/home-manager.nix
@@ -1,0 +1,67 @@
+# home-manager entry point for the my.* surface, for the standalone-HM hosts
+# (work-devserver, jasonbk-fedora) which have no system layer. A standalone host
+# is effectively single-user, so it exposes only the system scope (my.<tool>) and
+# installs finalPackage into home.packages. Hosts with a system layer use
+# ./nixos.nix / ./nix-darwin.nix instead.
+{
+  config,
+  lib,
+  pkgs,
+  neovimConfiguration ? null,
+  ...
+}: let
+  my = import ./lib.nix {inherit lib pkgs;};
+  inherit (my) defs myType mkTheme themeFor buildTool;
+
+  specialArgs = {inherit neovimConfiguration;};
+
+  systemStylix =
+    if config ? stylix
+    then config.stylix
+    else {};
+
+  theme = mkTheme {
+    stylixCfg = systemStylix;
+    colors =
+      if (config ? lib && config.lib ? stylix && config.lib.stylix ? colors)
+      then lib.filterAttrs (_: lib.isString) config.lib.stylix.colors
+      else {};
+  };
+in {
+  options.my = lib.mkOption {
+    type = myType;
+    default = {};
+  };
+
+  # finalPackage is unconditional (lazy); only the install + assertions are gated
+  # on enable. See the note in ./system-scope.nix on why gating finalPackage
+  # inside the `my` submodule causes infinite recursion.
+  config = lib.mkMerge [
+    {my.stylix.enable = lib.mkDefault (systemStylix.enable or false);}
+    {
+      my =
+        lib.mapAttrs (toolName: def: {
+          finalPackage = buildTool {
+            inherit def specialArgs;
+            theme = themeFor def config.my config.my.${toolName} theme;
+            toolCfg = config.my.${toolName};
+          };
+        })
+        defs;
+    }
+    {
+      home.packages =
+        lib.concatLists (lib.mapAttrsToList (toolName: _def:
+          lib.optional config.my.${toolName}.enable config.my.${toolName}.finalPackage)
+        defs);
+
+      assertions =
+        lib.concatLists (lib.mapAttrsToList (toolName: def:
+          lib.optionals (config.my.${toolName}.enable && def ? assertions) (def.assertions {
+            inherit specialArgs lib;
+            cfg = config.my.${toolName};
+          }))
+        defs);
+    }
+  ];
+}

--- a/modules/my/lib.nix
+++ b/modules/my/lib.nix
@@ -1,25 +1,16 @@
-# Framework for the `my.*` program surface. Turns the program definitions in
-# ./programs into a shared submodule type and the helpers the platform modules
-# (./system-scope.nix, ./home-manager.nix) use to cascade, theme, build, and
-# install. See ./programs/CONTRACT.md.
 {
   lib,
   pkgs,
 }: let
   defs = import ./programs {inherit lib pkgs;};
 
-  # Per-leaf `mkDefault`: recurse an attrset and wrap each leaf, stopping at
-  # derivations (so a `package` option is a leaf, not descended into). This is
-  # what makes the cascade deep-merge nested `settings` while letting the user
-  # win on scalars — a whole-attrset mkDefault would be dropped wholesale.
+  # Per-leaf (stops at derivations) so the cascade deep-merges nested settings
+  # and lets the user win on scalars; a whole-attrset mkDefault is dropped whole.
   recursiveMkDefault =
     lib.mapAttrsRecursiveCond
     (as: !(lib.isDerivation as))
     (_path: value: lib.mkDefault value);
 
-  # Resolve a stylix-ish config + base16 palette into the `theme` passed to a
-  # themeable tool's `build`. Returns null when stylix isn't enabled, so a host
-  # with no stylix is a no-op.
   mkTheme = {
     stylixCfg ? {},
     colors ? {},
@@ -33,8 +24,6 @@
       opacity = stylixCfg.opacity or {};
     };
 
-  # Options for one tool's submodule (under my.<name>). The framework owns
-  # enable/package/finalPackage/stylix.enable; the def supplies the rest.
   toolOptions = def:
     {
       enable = lib.mkEnableOption "${def.name} (my.* wrapped package) in this environment";
@@ -57,8 +46,6 @@
     }
     // (def.options or {});
 
-  # The shared submodule type used for BOTH the system scope (my.*) and the
-  # per-user scope (users.users.<n>.my.*).
   myType = lib.types.submodule {
     options =
       {
@@ -79,14 +66,11 @@
       defs;
   };
 
-  # Whether a tool should be themed in a given scope, and with which theme.
   themeFor = def: scopeMy: toolCfg: theme:
     if (def.themeable or false) && (scopeMy.stylix.enable or false) && (toolCfg.stylix.enable or true)
     then theme
     else null;
 
-  # Invoke a def's build with the resolved cfg (finalPackage stripped to avoid
-  # forcing it) and context.
   buildTool = {
     def,
     toolCfg,

--- a/modules/my/lib.nix
+++ b/modules/my/lib.nix
@@ -1,0 +1,102 @@
+# Framework for the `my.*` program surface. Turns the program definitions in
+# ./programs into a shared submodule type and the helpers the platform modules
+# (./system-scope.nix, ./home-manager.nix) use to cascade, theme, build, and
+# install. See ./programs/CONTRACT.md.
+{
+  lib,
+  pkgs,
+}: let
+  defs = import ./programs {inherit lib pkgs;};
+
+  # Per-leaf `mkDefault`: recurse an attrset and wrap each leaf, stopping at
+  # derivations (so a `package` option is a leaf, not descended into). This is
+  # what makes the cascade deep-merge nested `settings` while letting the user
+  # win on scalars — a whole-attrset mkDefault would be dropped wholesale.
+  recursiveMkDefault =
+    lib.mapAttrsRecursiveCond
+    (as: !(lib.isDerivation as))
+    (_path: value: lib.mkDefault value);
+
+  # Resolve a stylix-ish config + base16 palette into the `theme` passed to a
+  # themeable tool's `build`. Returns null when stylix isn't enabled, so a host
+  # with no stylix is a no-op.
+  mkTheme = {
+    stylixCfg ? {},
+    colors ? {},
+  }:
+    if !(stylixCfg.enable or false)
+    then null
+    else {
+      inherit colors;
+      polarity = stylixCfg.polarity or "dark";
+      fonts = stylixCfg.fonts or {};
+      opacity = stylixCfg.opacity or {};
+    };
+
+  # Options for one tool's submodule (under my.<name>). The framework owns
+  # enable/package/finalPackage/stylix.enable; the def supplies the rest.
+  toolOptions = def:
+    {
+      enable = lib.mkEnableOption "${def.name} (my.* wrapped package) in this environment";
+
+      finalPackage = lib.mkOption {
+        type = lib.types.package;
+        readOnly = true;
+        description = "The built ${def.name} package (read-only; set by the platform module).";
+      };
+    }
+    // lib.optionalAttrs ((def.defaultPackage or null) != null) {
+      package = lib.mkPackageOption pkgs def.defaultPackage {};
+    }
+    // lib.optionalAttrs (def.themeable or false) {
+      stylix.enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Theme this ${def.name} from stylix when the my.* stylix integration (my.stylix.enable) is on.";
+      };
+    }
+    // (def.options or {});
+
+  # The shared submodule type used for BOTH the system scope (my.*) and the
+  # per-user scope (users.users.<n>.my.*).
+  myType = lib.types.submodule {
+    options =
+      {
+        stylix.enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Master toggle for the my.* <-> stylix theming integration. Defaults to the host's stylix.enable.";
+        };
+      }
+      // lib.mapAttrs (
+        _name: def:
+          lib.mkOption {
+            type = lib.types.submodule {options = toolOptions def;};
+            default = {};
+            description = "my.${def.name} program (disabled by default).";
+          }
+      )
+      defs;
+  };
+
+  # Whether a tool should be themed in a given scope, and with which theme.
+  themeFor = def: scopeMy: toolCfg: theme:
+    if (def.themeable or false) && (scopeMy.stylix.enable or false) && (toolCfg.stylix.enable or true)
+    then theme
+    else null;
+
+  # Invoke a def's build with the resolved cfg (finalPackage stripped to avoid
+  # forcing it) and context.
+  buildTool = {
+    def,
+    toolCfg,
+    theme,
+    specialArgs,
+  }:
+    def.build {
+      cfg = removeAttrs toolCfg ["finalPackage"];
+      inherit pkgs lib theme specialArgs;
+    };
+in {
+  inherit defs myType recursiveMkDefault mkTheme themeFor buildTool;
+}

--- a/modules/my/nix-darwin.nix
+++ b/modules/my/nix-darwin.nix
@@ -1,7 +1,6 @@
-# nix-darwin entry point for the my.* surface. nix-darwin supports both
-# environment.systemPackages and users.users.<n>.packages (per-user profiles
-# under /etc/profiles/per-user/<name>, which precede the system profile in PATH),
-# so the system+per-user logic is shared with NixOS via ./system-scope.nix.
+# nix-darwin entry point for my.*. nix-darwin supports users.users.<n>.packages
+# (per-user profiles precede the system profile in PATH), so the system +
+# per-user logic is shared with NixOS via ./system-scope.nix.
 {...}: {
   imports = [./system-scope.nix];
 }

--- a/modules/my/nix-darwin.nix
+++ b/modules/my/nix-darwin.nix
@@ -1,0 +1,7 @@
+# nix-darwin entry point for the my.* surface. nix-darwin supports both
+# environment.systemPackages and users.users.<n>.packages (per-user profiles
+# under /etc/profiles/per-user/<name>, which precede the system profile in PATH),
+# so the system+per-user logic is shared with NixOS via ./system-scope.nix.
+{...}: {
+  imports = [./system-scope.nix];
+}

--- a/modules/my/nixos.nix
+++ b/modules/my/nixos.nix
@@ -1,0 +1,7 @@
+# NixOS entry point for the my.* surface. Installs my.<tool> into
+# environment.systemPackages (system scope) and users.users.<n>.my.<tool> into
+# users.users.<n>.packages (per-user scope). The system+per-user logic is shared
+# with nix-darwin via ./system-scope.nix.
+{...}: {
+  imports = [./system-scope.nix];
+}

--- a/modules/my/nixos.nix
+++ b/modules/my/nixos.nix
@@ -1,7 +1,5 @@
-# NixOS entry point for the my.* surface. Installs my.<tool> into
-# environment.systemPackages (system scope) and users.users.<n>.my.<tool> into
-# users.users.<n>.packages (per-user scope). The system+per-user logic is shared
-# with nix-darwin via ./system-scope.nix.
+# NixOS entry point for my.*. System + per-user logic is shared with nix-darwin
+# via ./system-scope.nix.
 {...}: {
   imports = [./system-scope.nix];
 }

--- a/modules/my/programs/CONTRACT.md
+++ b/modules/my/programs/CONTRACT.md
@@ -1,0 +1,81 @@
+# `modules/my/programs/<tool>.nix` — the program-definition contract
+
+Every file here is a **program definition**: a function `{ lib, pkgs }: { … }`
+returning ONE shape. The framework (`../lib.nix`) turns each def into the
+`my.<name>` (system) and `users.users.<n>.my.<name>` (per-user) option surfaces,
+and the platform modules (`../nixos.nix`, `../nix-darwin.nix`,
+`../home-manager.nix`) install the built package into the right environment.
+
+**All programs are disabled by default.** A host opts in with `my.<name>.enable`
+(system-wide) or `users.users.<n>.my.<name>.enable` (one user).
+
+## The shape
+
+```nix
+{ lib, pkgs }: {
+  # REQUIRED
+  name = "jujutsu";                 # key under my.<name>
+  build = { cfg, pkgs, lib, theme ? null, specialArgs ? {}, ... }:
+    # Return the package to install. `cfg` is the resolved option set for this
+    # scope (enable, package, + your `options`, + stylix if themeable) WITHOUT
+    # finalPackage. Use pkgs.mkWrapped to bake config. Must be pure over
+    # cfg/theme/specialArgs only — do NOT read the ambient module `config`.
+    pkgs.mkWrapped {
+      pkg = cfg.package;
+      name = "jj";
+      env.JJ_CONFIG = (pkgs.formats.toml {}).generate "jj-config.toml" cfg.settings;
+    };
+
+  # OPTIONAL
+  defaultPackage = "jujutsu";       # pkgs attr (string or ["a" "b"]) -> adds a
+                                    # `package` option (mkPackageOption). Omit
+                                    # for tools that don't wrap one pkgs attr
+                                    # (e.g. nvf builds via a specialArg).
+  options = {                       # extra tool options, merged under my.<name>
+    settings = lib.mkOption { type = (pkgs.formats.toml {}).type; default = {}; … };
+  };
+  themeable = true;                 # opt into stylix: adds my.<name>.stylix.enable
+                                    # (default true) and passes a resolved `theme`
+                                    # (or null) into build. Omit for un-themeable
+                                    # tools (fd, rg, git, jj, gh).
+  assertions = { cfg, specialArgs, lib }: [   # checked under mkIf enable
+    { assertion = specialArgs.neovimConfiguration or null != null;
+      message = "my.nvf.enable requires the neovimConfiguration specialArg."; }
+  ];
+}
+```
+
+## Universal options the framework adds (do NOT declare these yourself)
+
+- `enable` — `mkEnableOption`, default **false**.
+- `package` — only when `defaultPackage` is set.
+- `finalPackage` — read-only; `= build { cfg = <resolved>; … }`. Tests read this.
+- `stylix.enable` — only when `themeable = true`; default true.
+
+## Cascade (system → per-user)
+
+`users.users.<n>.my.<tool>.enable` defaults **false** (explicit opt-in). Every
+*other* option deep-merges from the system `my.<tool>` value via per-leaf
+`mkDefault`, so a user only writes the delta and wins on conflicts. You don't
+implement this — the framework does. Just make `build` a pure function of `cfg`.
+
+## stylix (themeable tools)
+
+When `themeable`, `build` receives `theme` = `{ colors; polarity; fonts; opacity; }`
+(base16 `colors` are `base00`..`base0F`, hex without `#`) when the integration is
+on for this tool, else `null`. Bake it into the config and let the user's own
+`settings` win (e.g. `lib.recursiveUpdate (themed theme) cfg.settings`). The
+global toggle is `my.stylix.enable`; per-tool is `my.<tool>.stylix.enable`.
+
+## Tests
+
+Add `../tests/<name>-wrapper.nix` — a `{ pkgs, inputs ? null }` -> nixosTest that
+asserts the **plumbing** (sentinel through `settings` -> read back via the wrapped
+binary), never a real default. See `../tests/jujutsu-wrapper.nix`.
+
+## Do NOT
+
+- declare `enable`/`package`/`finalPackage`/`stylix.enable` (framework owns them);
+- read the ambient module `config` inside `build` (only `cfg`/`theme`/`specialArgs`);
+- edit `default.nix` — it auto-discovers every `*.nix` here; just drop your file;
+- set system state (shells, login shell, services) — out of `my.*` scope.

--- a/modules/my/programs/default.nix
+++ b/modules/my/programs/default.nix
@@ -1,0 +1,17 @@
+# Auto-collects every program definition (*.nix here, except this file) into an
+# attrset keyed by each def's `name`. Drop a new modules/my/programs/<tool>.nix
+# conforming to ./CONTRACT.md and it's picked up automatically — no edits here.
+{
+  lib,
+  pkgs,
+}: let
+  # A def is either a `<tool>.nix` file or a `<tool>/` directory (with its own
+  # default.nix returning the def). CONTRACT.md and this default.nix are skipped.
+  isDef = name: type:
+    type
+    == "directory"
+    || (type == "regular" && name != "default.nix" && lib.hasSuffix ".nix" name);
+  files = lib.filterAttrs isDef (builtins.readDir ./.);
+  defs = lib.mapAttrsToList (fname: _: import (./. + "/${fname}") {inherit lib pkgs;}) files;
+in
+  lib.listToAttrs (map (def: lib.nameValuePair def.name def) defs)

--- a/modules/my/programs/default.nix
+++ b/modules/my/programs/default.nix
@@ -1,12 +1,9 @@
-# Auto-collects every program definition (*.nix here, except this file) into an
-# attrset keyed by each def's `name`. Drop a new modules/my/programs/<tool>.nix
-# conforming to ./CONTRACT.md and it's picked up automatically — no edits here.
+# Auto-collects every program def (file or dir) into an attrset keyed by `name`.
+# See ./CONTRACT.md.
 {
   lib,
   pkgs,
 }: let
-  # A def is either a `<tool>.nix` file or a `<tool>/` directory (with its own
-  # default.nix returning the def). CONTRACT.md and this default.nix are skipped.
   isDef = name: type:
     type
     == "directory"

--- a/modules/my/programs/direnv.nix
+++ b/modules/my/programs/direnv.nix
@@ -1,15 +1,3 @@
-# Program definition for a per-user WRAPPED direnv (my.direnv). Replaces the OLD
-# native programs.direnv system module (programs.direnv + nix-direnv): instead of
-# a system-wide direnvrc and shell hooks, this bakes a private config dir (pointed
-# at via $DIRENV_CONFIG) carrying direnvrc (sourcing nix-direnv) and direnv.toml,
-# so a single user gets a configured direnv on PATH without any system module.
-#
-# direnv resolves its config dir from $DIRENV_CONFIG (overriding the default
-# $XDG_CONFIG_HOME/direnv); that dir holds `direnvrc` and `direnv.toml`. The
-# `direnv hook <shell>` line is NOT baked here — it lives in the shell wrappers
-# (my.fish etc.). direnv must be installed in the same environment as the shell.
-# See ./CONTRACT.md and docs/plans/2026-06-09-my-namespace-wrappers-design-final.md
-# ("fish & direnv").
 {
   lib,
   pkgs,

--- a/modules/my/programs/direnv.nix
+++ b/modules/my/programs/direnv.nix
@@ -1,0 +1,86 @@
+# Program definition for a per-user WRAPPED direnv (my.direnv). Replaces the OLD
+# native programs.direnv system module (programs.direnv + nix-direnv): instead of
+# a system-wide direnvrc and shell hooks, this bakes a private config dir (pointed
+# at via $DIRENV_CONFIG) carrying direnvrc (sourcing nix-direnv) and direnv.toml,
+# so a single user gets a configured direnv on PATH without any system module.
+#
+# direnv resolves its config dir from $DIRENV_CONFIG (overriding the default
+# $XDG_CONFIG_HOME/direnv); that dir holds `direnvrc` and `direnv.toml`. The
+# `direnv hook <shell>` line is NOT baked here — it lives in the shell wrappers
+# (my.fish etc.). direnv must be installed in the same environment as the shell.
+# See ./CONTRACT.md and docs/plans/2026-06-09-my-namespace-wrappers-design-final.md
+# ("fish & direnv").
+{
+  lib,
+  pkgs,
+}: let
+  tomlFormat = pkgs.formats.toml {};
+in {
+  name = "direnv";
+  defaultPackage = "direnv";
+
+  options = {
+    enableNixDirenv = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Source nix-direnv's direnvrc into this wrapper's baked direnvrc, giving
+        the faster cached `use nix` / `use flake`. Replaces the OLD native
+        programs.direnv.nix-direnv.enable.
+      '';
+    };
+
+    stdlib = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      example = ''
+        export_function() { … }
+      '';
+      description = ''
+        Extra direnvrc content baked into this wrapper, appended after the
+        nix-direnv source line. Equivalent to ~/.config/direnv/direnvrc.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = tomlFormat.type;
+      default = {};
+      example = {
+        global.warn_timeout = "1m";
+        whitelist.prefix = ["/home/me/projects"];
+      };
+      description = ''
+        direnv.toml content baked into this wrapper's config dir (pointed at via
+        $DIRENV_CONFIG).
+      '';
+    };
+  };
+
+  build = {
+    cfg,
+    pkgs,
+    lib,
+    ...
+  }: let
+    direnvrc =
+      lib.optionalString cfg.enableNixDirenv
+      "source ${pkgs.nix-direnv}/share/nix-direnv/direnvrc\n"
+      + cfg.stdlib;
+
+    configDir = pkgs.linkFarm "my-direnv-config" [
+      {
+        name = "direnvrc";
+        path = pkgs.writeText "direnvrc" direnvrc;
+      }
+      {
+        name = "direnv.toml";
+        path = tomlFormat.generate "direnv.toml" cfg.settings;
+      }
+    ];
+  in
+    pkgs.mkWrapped {
+      pkg = cfg.package;
+      name = "direnv";
+      env.DIRENV_CONFIG = "${configDir}";
+    };
+}

--- a/modules/my/programs/fd.nix
+++ b/modules/my/programs/fd.nix
@@ -1,4 +1,3 @@
-# fd program definition. See ./CONTRACT.md.
 {
   lib,
   pkgs,

--- a/modules/my/programs/fd.nix
+++ b/modules/my/programs/fd.nix
@@ -1,0 +1,14 @@
+# fd program definition. See ./CONTRACT.md.
+{
+  lib,
+  pkgs,
+}: {
+  name = "fd";
+  defaultPackage = "fd";
+
+  build = {
+    cfg,
+    ...
+  }:
+    cfg.package;
+}

--- a/modules/my/programs/fish.nix
+++ b/modules/my/programs/fish.nix
@@ -1,10 +1,3 @@
-# Program definition for a per-user WRAPPED fish (my.fish). Replaces the OLD
-# native programs.fish system module: instead of system-wide interactiveShellInit
-# + system-profile vendor loading, this bakes a private config dir (pointed at via
-# $__fish_config_dir) carrying the init hooks and plugin vendor-path wiring, so a
-# single user gets a configured fish on PATH without any system fish module.
-# See ./CONTRACT.md and docs/plans/2026-06-09-my-namespace-wrappers-design-final.md
-# ("fish & direnv").
 {
   lib,
   pkgs,
@@ -46,11 +39,8 @@
     lib,
     ...
   }: let
-    # Prepend each plugin's vendor dirs onto fish's search/source paths. fish has
-    # no env-var equivalent for these, so we emit a conf.d snippet that runs
-    # before user config (conf.d files are sourced in alphabetical order, hence
-    # the 00- prefix). vendor_conf.d files are sourced explicitly since adding to
-    # a search path alone does not auto-source already-loaded conf.d.
+    # vendor_conf.d is sourced explicitly: prepending the search path alone does
+    # not auto-source conf.d fish has already scanned.
     pluginVendorSnippet = let
       forPlugin = p: ''
         if test -d ${p}/share/fish/vendor_completions.d
@@ -79,13 +69,9 @@
       }
     ];
   in
-    # fish reads config.fish/conf.d from $__fish_config_dir (defaults to
-    # $XDG_CONFIG_HOME/fish). Setting it via --set points fish at our baked dir
-    # without clobbering XDG_CONFIG_HOME / XDG_DATA_DIRS. Plugin packages are also
-    # placed on PATH so any binaries they ship resolve.
-    # TODO(#42): conf.d-only config dir (no config.fish); vendor-completion parity
-    # relies on plugins shipping vendor_completions.d. carapace/vivid/full vendor
-    # machinery from the old system module are not yet reproduced here.
+    # TODO(#42): vendor-completion parity relies on plugins shipping
+    # vendor_completions.d; carapace/vivid from the old system module aren't
+    # reproduced here yet.
     pkgs.mkWrapped {
       pkg = cfg.package;
       name = "fish";

--- a/modules/my/programs/fish.nix
+++ b/modules/my/programs/fish.nix
@@ -1,0 +1,95 @@
+# Program definition for a per-user WRAPPED fish (my.fish). Replaces the OLD
+# native programs.fish system module: instead of system-wide interactiveShellInit
+# + system-profile vendor loading, this bakes a private config dir (pointed at via
+# $__fish_config_dir) carrying the init hooks and plugin vendor-path wiring, so a
+# single user gets a configured fish on PATH without any system fish module.
+# See ./CONTRACT.md and docs/plans/2026-06-09-my-namespace-wrappers-design-final.md
+# ("fish & direnv").
+{
+  lib,
+  pkgs,
+}: {
+  name = "fish";
+  defaultPackage = "fish";
+
+  options = {
+    interactiveShellInit = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      example = ''
+        starship init fish | source
+        direnv hook fish | source
+      '';
+      description = ''
+        Fish snippet baked into this wrapper's conf.d, sourced on every
+        interactive session start (e.g. starship/direnv hooks). Replaces the
+        OLD native programs.fish.interactiveShellInit.
+      '';
+    };
+
+    plugins = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [];
+      example = lib.literalExpression "[ pkgs.fishPlugins.plugin-git ]";
+      description = ''
+        Fish plugin packages whose share/fish/vendor_* dirs should resolve in
+        this wrapper. Their vendor_completions.d / vendor_functions.d /
+        vendor_conf.d are prepended onto fish's search paths via a baked conf.d
+        snippet (replaces the OLD system-profile vendor loading).
+      '';
+    };
+  };
+
+  build = {
+    cfg,
+    pkgs,
+    lib,
+    ...
+  }: let
+    # Prepend each plugin's vendor dirs onto fish's search/source paths. fish has
+    # no env-var equivalent for these, so we emit a conf.d snippet that runs
+    # before user config (conf.d files are sourced in alphabetical order, hence
+    # the 00- prefix). vendor_conf.d files are sourced explicitly since adding to
+    # a search path alone does not auto-source already-loaded conf.d.
+    pluginVendorSnippet = let
+      forPlugin = p: ''
+        if test -d ${p}/share/fish/vendor_completions.d
+            set -p fish_complete_path ${p}/share/fish/vendor_completions.d
+        end
+        if test -d ${p}/share/fish/vendor_functions.d
+            set -p fish_function_path ${p}/share/fish/vendor_functions.d
+        end
+        if test -d ${p}/share/fish/vendor_conf.d
+            for __my_fish_conf in ${p}/share/fish/vendor_conf.d/*.fish
+                source $__my_fish_conf
+            end
+        end
+      '';
+    in
+      lib.concatMapStringsSep "\n" forPlugin cfg.plugins;
+
+    confD = pkgs.linkFarm "my-fish-conf.d" [
+      {
+        name = "conf.d/00-my-plugins.fish";
+        path = pkgs.writeText "00-my-plugins.fish" pluginVendorSnippet;
+      }
+      {
+        name = "conf.d/00-my-init.fish";
+        path = pkgs.writeText "00-my-init.fish" cfg.interactiveShellInit;
+      }
+    ];
+  in
+    # fish reads config.fish/conf.d from $__fish_config_dir (defaults to
+    # $XDG_CONFIG_HOME/fish). Setting it via --set points fish at our baked dir
+    # without clobbering XDG_CONFIG_HOME / XDG_DATA_DIRS. Plugin packages are also
+    # placed on PATH so any binaries they ship resolve.
+    # TODO(#42): conf.d-only config dir (no config.fish); vendor-completion parity
+    # relies on plugins shipping vendor_completions.d. carapace/vivid/full vendor
+    # machinery from the old system module are not yet reproduced here.
+    pkgs.mkWrapped {
+      pkg = cfg.package;
+      name = "fish";
+      env.__fish_config_dir = "${confD}";
+      extraPaths = cfg.plugins;
+    };
+}

--- a/modules/my/programs/gh.nix
+++ b/modules/my/programs/gh.nix
@@ -1,0 +1,36 @@
+# gh program definition. See ./CONTRACT.md.
+{
+  lib,
+  pkgs,
+}: let
+  yamlFormat = pkgs.formats.yaml {};
+in {
+  name = "gh";
+  defaultPackage = "gh";
+
+  options = {
+    settings = lib.mkOption {
+      type = yamlFormat.type;
+      default = {};
+      example = {editor = "nvim";};
+      description = ''
+        gh config. Only `editor` is baked (pinned as GH_EDITOR); the rest of
+        gh's config and its auth (hosts.yml) stay in the real GH_CONFIG_DIR so
+        `gh auth login` keeps working.
+      '';
+    };
+  };
+
+  build = {
+    cfg,
+    pkgs,
+    ...
+  }:
+    pkgs.mkWrapped {
+      pkg = cfg.package;
+      name = "gh";
+      env = lib.optionalAttrs (cfg.settings ? editor) {
+        GH_EDITOR = cfg.settings.editor;
+      };
+    };
+}

--- a/modules/my/programs/gh.nix
+++ b/modules/my/programs/gh.nix
@@ -1,4 +1,3 @@
-# gh program definition. See ./CONTRACT.md.
 {
   lib,
   pkgs,

--- a/modules/my/programs/ghostty.nix
+++ b/modules/my/programs/ghostty.nix
@@ -1,6 +1,3 @@
-# ghostty program definition. See ./CONTRACT.md. Themeable: bakes the per-scope
-# stylix base16 palette into the wrapper's --config-file, while the user's own
-# `settings` win on conflicts.
 {
   lib,
   pkgs,

--- a/modules/my/programs/ghostty.nix
+++ b/modules/my/programs/ghostty.nix
@@ -1,0 +1,99 @@
+# ghostty program definition. See ./CONTRACT.md. Themeable: bakes the per-scope
+# stylix base16 palette into the wrapper's --config-file, while the user's own
+# `settings` win on conflicts.
+{
+  lib,
+  pkgs,
+}: let
+  renderValue = v:
+    if lib.isBool v
+    then lib.boolToString v
+    else toString v;
+
+  renderEntry = key: value:
+    if lib.isList value
+    then map (item: "${key} = ${renderValue item}") value
+    else ["${key} = ${renderValue value}"];
+
+  renderConfig = settings:
+    lib.concatStringsSep "\n" (lib.concatLists (lib.mapAttrsToList renderEntry settings)) + "\n";
+
+  # base16 → 16-colour ANSI terminal slots, the standard base16 mapping
+  # (bright variants reuse the normal accent hues).
+  ansiPalette = c: [
+    c.base00 # 0  black
+    c.base08 # 1  red
+    c.base0B # 2  green
+    c.base0A # 3  yellow
+    c.base0D # 4  blue
+    c.base0E # 5  magenta
+    c.base0C # 6  cyan
+    c.base05 # 7  white
+    c.base03 # 8  bright black
+    c.base08 # 9  bright red
+    c.base0B # 10 bright green
+    c.base0A # 11 bright yellow
+    c.base0D # 12 bright blue
+    c.base0E # 13 bright magenta
+    c.base0C # 14 bright cyan
+    c.base07 # 15 bright white
+  ];
+
+  # TODO: only the base16 palette is mapped; wire `theme.fonts` into ghostty's
+  # font-family/font-size and `theme.opacity.terminal` into background-opacity to
+  # match HM-stylix's ghostty target.
+  # https://github.com/jasonboukheir/dotfiles/issues/44
+  themedSettings = theme: let
+    c = theme.colors;
+  in {
+    background = "#${c.base00}";
+    foreground = "#${c.base05}";
+    cursor-color = "#${c.base05}";
+    cursor-text = "#${c.base00}";
+    selection-background = "#${c.base02}";
+    selection-foreground = "#${c.base05}";
+    palette = lib.imap0 (i: hex: "${toString i}=#${hex}") (ansiPalette c);
+  };
+in {
+  name = "ghostty";
+  defaultPackage = "ghostty";
+  themeable = true;
+
+  options = {
+    settings = lib.mkOption {
+      type = with lib.types; attrsOf (oneOf [bool int str (listOf str)]);
+      default = {};
+      example = {
+        theme = "GruvboxDark";
+        palette = ["0=#1d2021" "1=#cc241d"];
+      };
+      description = ''
+        ghostty config baked into this wrapper and loaded via `--config-file`.
+        List values render as repeated `key = item` lines (e.g. `palette`). When
+        stylix theming is on, the base16 palette populates the color keys; these
+        `settings` still win on conflicts, as does the user's own
+        `~/.config/ghostty/config`.
+      '';
+    };
+  };
+
+  build = {
+    cfg,
+    pkgs,
+    lib,
+    theme ? null,
+    ...
+  }: let
+    finalSettings =
+      if theme == null
+      then cfg.settings
+      else lib.recursiveUpdate (themedSettings theme) cfg.settings;
+
+    configFile = pkgs.writeText "ghostty-config" (renderConfig finalSettings);
+  in
+    pkgs.mkWrapped {
+      pkg = cfg.package;
+      name = "ghostty";
+      flags = lib.optional (finalSettings != {}) "--config-file=${configFile}";
+    };
+}

--- a/modules/my/programs/git.nix
+++ b/modules/my/programs/git.nix
@@ -1,0 +1,58 @@
+# Program definition for git. See ./CONTRACT.md.
+{
+  lib,
+  pkgs,
+}: let
+  gitIniFormat = pkgs.formats.gitIni {};
+
+  lfsFilter = {
+    clean = "git-lfs clean -- %f";
+    smudge = "git-lfs smudge -- %f";
+    process = "git-lfs filter-process";
+    required = true;
+  };
+in {
+  name = "git";
+  defaultPackage = "git";
+
+  options = {
+    lfs.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Put git-lfs on the wrapper PATH and bake its filters into GIT_CONFIG_GLOBAL.";
+    };
+
+    ignores = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      example = [".DS_Store"];
+      description = "Patterns baked into a gitignore and wired as core.excludesFile.";
+    };
+
+    settings = lib.mkOption {
+      type = gitIniFormat.type;
+      default = {};
+      example = {init.defaultBranch = "main";};
+      description = "Settings baked into this git wrapper via GIT_CONFIG_GLOBAL.";
+    };
+  };
+
+  build = {
+    cfg,
+    pkgs,
+    ...
+  }: let
+    excludesFile = pkgs.writeText "gitignore" (lib.concatStringsSep "\n" cfg.ignores);
+    bakedConfig = lib.foldl' lib.recursiveUpdate {} [
+      cfg.settings
+      (lib.optionalAttrs (cfg.ignores != []) {core.excludesFile = "${excludesFile}";})
+      (lib.optionalAttrs cfg.lfs.enable {filter.lfs = lfsFilter;})
+    ];
+  in
+    pkgs.mkWrapped {
+      pkg = cfg.package;
+      name = "git";
+      extraPaths = lib.optional cfg.lfs.enable pkgs.git-lfs;
+      env.GIT_CONFIG_GLOBAL = gitIniFormat.generate "gitconfig" bakedConfig;
+    };
+}

--- a/modules/my/programs/git.nix
+++ b/modules/my/programs/git.nix
@@ -1,4 +1,3 @@
-# Program definition for git. See ./CONTRACT.md.
 {
   lib,
   pkgs,

--- a/modules/my/programs/jujutsu.nix
+++ b/modules/my/programs/jujutsu.nix
@@ -1,0 +1,30 @@
+# Reference program definition. See ./CONTRACT.md.
+{
+  lib,
+  pkgs,
+}: let
+  tomlFormat = pkgs.formats.toml {};
+in {
+  name = "jujutsu";
+  defaultPackage = "jujutsu";
+
+  options = {
+    settings = lib.mkOption {
+      type = tomlFormat.type;
+      default = {};
+      example = {ui.editor = "nvim";};
+      description = "Settings baked into this jj wrapper via JJ_CONFIG.";
+    };
+  };
+
+  build = {
+    cfg,
+    pkgs,
+    ...
+  }:
+    pkgs.mkWrapped {
+      pkg = cfg.package;
+      name = "jj";
+      env.JJ_CONFIG = tomlFormat.generate "jj-config.toml" cfg.settings;
+    };
+}

--- a/modules/my/programs/jujutsu.nix
+++ b/modules/my/programs/jujutsu.nix
@@ -1,4 +1,3 @@
-# Reference program definition. See ./CONTRACT.md.
 {
   lib,
   pkgs,

--- a/modules/my/programs/nushell/config.nu
+++ b/modules/my/programs/nushell/config.nu
@@ -1,0 +1,266 @@
+# returns the name of the current branch
+export def git_current_branch [] {
+    ^git rev-parse --abbrev-ref HEAD
+}
+
+export def git_main_branch [] {
+    git remote show origin
+        | lines
+        | str trim
+        | find --regex 'HEAD .*?[：: ].+'
+        | first
+        | ansi strip
+        | str replace --regex 'HEAD .*?[：: ]\s*(.+)' '$1'
+}
+
+#
+# Aliases
+# (sorted alphabetically)
+#
+
+export alias ga = git add
+export alias gaa = git add --all
+export alias gapa = git add --patch
+export alias gau = git add --update
+export alias gav = git add --verbose
+export alias gap = git apply
+export alias gapt = git apply --3way
+
+export alias gb = git branch
+export alias gba = git branch --all
+export alias gbd = git branch --delete
+export alias gbD = git branch --delete --force
+export alias gbl = git blame -b -w
+export alias gbm = git branch --move
+export alias gbmc = git branch --move (git_current_branch)
+export alias gbnm = git branch --no-merged
+export alias gbr = git branch --remote
+export alias gbs = git bisect
+export alias gbsb = git bisect bad
+export alias gbsg = git bisect good
+export alias gbsn = git bisect new
+export alias gbso = git bisect old
+export alias gbsr = git bisect reset
+export alias gbss = git bisect start
+
+export alias gc = git commit --verbose
+export alias gc! = git commit --verbose --amend
+export alias gcn = git commit --verbose --no-edit
+export alias gcn! = git commit --verbose --no-edit --amend
+export alias gca = git commit --verbose --all
+export alias gca! = git commit --verbose --all --amend
+export alias gcan! = git commit --verbose --all --no-edit --amend
+export alias gcans! = git commit --verbose --all --signoff --no-edit --amend
+export def gcam [message: string] {
+    git commit --all --message $message
+}
+export def gcsm [message: string] {
+    git commit --all --signoff $message
+}
+export alias gcas = git commit --all --signoff
+export def gcasm [message: string] {
+    git commit --all --signoff --message $message
+}
+export alias gcb = git checkout -b
+export alias gcd = git checkout develop
+export alias gcf = git config --list
+export alias gcl = git clone --recurse-submodules
+export alias gclean = git clean --interactive -d
+export def gpristine [] {
+    git reset --hard
+    git clean -d --force -x
+}
+export alias gcm = git checkout (git_main_branch)
+export def gcmsg [message: string] {
+    git commit --message $message
+}
+export alias gco = git checkout
+export alias gcor = git checkout --recurse-submodules
+export alias gcount = git shortlog --summary --numbered
+export alias gcp = git cherry-pick
+export alias gcpa = git cherry-pick --abort
+export alias gcpc = git cherry-pick --continue
+export alias gcs = git commit --gpg-sign
+export alias gcss = git commit --gpg-sign --signoff
+export def gcssm [message: string] {
+    git commit --gpg-sign --signoff --message $message
+}
+export alias gd = git diff
+export alias gdca = git diff --cached
+export alias gdcw = git diff --cached --word-diff
+export alias gdct = git describe --tags (git rev-list --tags --max-count=1)
+export alias gds = git diff --staged
+export alias gdt = git diff-tree --no-commit-id --name-only -r
+export alias gdup = git diff @{upstream}
+export alias gdw = git diff --word-diff
+
+export alias gf = git fetch
+export alias gfa = git fetch --all --prune
+export alias gfo = git fetch origin
+
+export alias gg = git gui citool
+export alias gga = git gui citool --amend
+
+export alias ghh = git help
+
+export alias gignore = git update-index --assume-unchanged
+
+export alias gl = git log
+export alias glg = git log --stat
+export alias glgp = git log --stat --patch
+export alias glgg = git log --graph
+export alias glgga = git log --graph --decorate --all
+export alias glgm = git log --graph --max-count=10
+export alias glo = git log --oneline --decorate
+export alias glod = git log --graph $'--pretty=%Cred%h%Creset -%C(char lp)auto(char rp)%d%Creset %s %Cgreen(char lp)%ad(char rp) %C(char lp)bold blue(char rp)<%an>%Creset'
+export alias glods = git log --graph $'--pretty=%Cred%h%Creset -%C(char lp)auto(char rp)%d%Creset %s %Cgreen(char lp)%ad(char rp) %C(char lp)bold blue(char rp)<%an>%Creset' --date=short
+export alias glog = git log --oneline --decorate --graph
+export alias gloga = git log --oneline --decorate --graph --all
+export alias glol = git log --graph $'--pretty=%Cred%h%Creset -%C(char lp)auto(char rp)%d%Creset %s %Cgreen(char lp)%ar(char rp) %C(char lp)bold blue(char rp)<%an>%Creset'
+export alias glola = git log --graph $'--pretty=%Cred%h%Creset -%C(char lp)auto(char rp)%d%Creset %s %Cgreen(char lp)%ar(char rp) %C(char lp)bold blue(char rp)<%an>%Creset' --all
+export alias glols = git log --graph $'--pretty=%Cred%h%Creset -%C(char lp)auto(char rp)%d%Creset %s %Cgreen(char lp)%ar(char rp) %C(char lp)bold blue(char rp)<%an>%Creset' --stat
+
+export alias gm = git merge
+export alias gmtl = git mergetool --no-prompt
+export alias gmtlvim = git mergetool --no-prompt --tool=vimdiff
+export alias gma = git merge --abort
+export def gmom [] {
+    let main = (git_main_branch)
+    git merge $"origin/($main)"
+}
+
+export alias gp = git push
+export alias gpd = git push --dry-run
+export alias gpf = git push --force-with-lease
+export alias gpf! = git push --force
+export alias gpl = git pull
+export def gpoat [] {
+    git push origin --all; git push origin --tags
+}
+export alias gpod = git push origin --delete
+export alias gpodc = git push origin --delete (git_current_branch)
+def "nu-complete git pull rebase" [] {
+  ["false","true","merges","interactive"]
+}
+export def gpr [rebase_type: string@"nu-complete git pull rebase"] {
+    git pull --rebase $rebase_type
+}
+export alias gpu = git push upstream
+export alias gpv = git push --verbose
+
+export alias gr = git remote
+export alias gpra = git pull --rebase --autostash
+export alias gprav = git pull --rebase --autostash --verbose
+export alias gprv = git pull --rebase --verbose
+export alias gpsup = git push --set-upstream origin (git_current_branch)
+export alias gra = git remote add
+export alias grb = git rebase
+export alias grba = git rebase --abort
+export alias grbc = git rebase --continue
+export alias grbd = git rebase develop
+export alias grbi = git rebase --interactive
+export alias grbm = git rebase (git_main_branch)
+export alias grbo = git rebase --onto
+export alias grbs = git rebase --skip
+export alias grev = git revert
+export alias grh = git reset
+export alias grhh = git reset --hard
+export alias groh = git reset $"origin/(git_current_branch)" --hard
+export alias grm = git rm
+export alias grmc = git rm --cached
+export def grmv [remote: string, new_name: string] {
+    git remote rename $remote $new_name
+}
+export def grrm [remote: string] {
+    git remote remove $remote
+}
+export alias grs = git restore
+export def grset [remote: string, url: string] {
+    git remote set-url $remote $url
+}
+export alias grss = git restore --source
+export alias grst = git restore --staged
+export alias grt = cd (git rev-parse --show-toplevel or echo .)
+export alias gru = git reset --
+export alias grup = git remote update
+export alias grv = git remote --verbose
+
+export alias gsb = git status --short --branch
+export alias gsd = git svn dcommit
+export alias gsh = git show
+export alias gshs = git show -s
+export alias gsi = git submodule init
+export alias gsps = git show --pretty=short --show-signature
+export alias gsr = git svn rebase
+export alias gss = git status --short
+export alias gst = git status
+
+export alias gsta = git stash push
+export alias gstaa = git stash apply
+export alias gstc = git stash clear
+export alias gstd = git stash drop
+export alias gstl = git stash list
+export alias gstp = git stash pop
+export alias gsts = git stash show --text
+export alias gstu = gsta --include-untracked
+export alias gstall = git stash --all
+export alias gsu = git submodule update
+export alias gsw = git switch
+export alias gswc = git switch --create
+
+export alias gts = git tag --sign
+export def gtv [] {
+    git tag | lines | sort
+}
+export alias glum = git pull upstream (git_main_branch)
+
+export alias gunignore = git update-index --no-assume-unchanged
+export def gup [rebase_type: string@"nu-complete git pull rebase"] {
+    git pull --rebase $rebase_type
+}
+export alias gupv = git pull --rebase --verbose
+export alias gupa = git pull --rebase --autostash
+export alias gupav = git pull --rebase --autostash --verbose
+
+export alias gwch = git whatchanged -p --abbrev-commit --pretty=medium
+
+export alias gwt = git worktree
+export def gwta [path: path, branch?: string] {
+    if $branch != null {
+        git worktree add $path $branch
+    } else {
+	git worktree add $path
+    }
+}
+export alias gwtls = git worktree list
+export alias gwtmv = git worktree move
+export def gwtm [worktree: string] {
+    git worktree remove $worktree
+}
+
+export alias gam = git am
+export alias gamc = git am --continue
+export alias gams = git am --skip
+export alias gama = git am --abort
+export alias gamscp = git am --show-current-patch
+
+let carapace_completer = {|spans|
+       carapace $spans.0 nushell ...$spans | from json
+       }
+
+$env.config = {
+    completions: {
+    case_sensitive: false # case-sensitive completions
+    quick: true    # set to false to prevent auto-selecting completions
+    partial: true    # set to false to prevent partial filling of the prompt
+    algorithm: "fuzzy"    # prefix or fuzzy
+    external: {
+    # set to false to prevent nushell looking into $env.PATH to find more suggestions
+        enable: true
+    # set to lower can improve completion performance at the cost of omitting some options
+        max_results: 100
+        completer: $carapace_completer # check 'carapace_completer'
+        }
+    }
+    show_banner: false
+}

--- a/modules/my/programs/nushell/default.nix
+++ b/modules/my/programs/nushell/default.nix
@@ -1,14 +1,3 @@
-# nushell program definition. See ../CONTRACT.md.
-#
-# Bakes config.nu (loaded via --config) and a generated env.nu (via
-# --env-config) into a mkWrapped nu. The env.nu carries the two gotcha hooks the
-# old module had: vivid's $env.LS_COLORS and `starship init nu` written into
-# nushell's vendor autoload dir. carapace rides on the wrapper PATH so the baked
-# config.nu external completer can call it.
-#
-# NOT themeable: the default vivid `ansi` theme renders file types through the
-# terminal's 16 ANSI slots, which stylix themes from base16 elsewhere, so
-# LS_COLORS tracks the scheme without a stylix target here.
 {
   lib,
   pkgs,

--- a/modules/my/programs/nushell/default.nix
+++ b/modules/my/programs/nushell/default.nix
@@ -1,0 +1,102 @@
+# nushell program definition. See ../CONTRACT.md.
+#
+# Bakes config.nu (loaded via --config) and a generated env.nu (via
+# --env-config) into a mkWrapped nu. The env.nu carries the two gotcha hooks the
+# old module had: vivid's $env.LS_COLORS and `starship init nu` written into
+# nushell's vendor autoload dir. carapace rides on the wrapper PATH so the baked
+# config.nu external completer can call it.
+#
+# NOT themeable: the default vivid `ansi` theme renders file types through the
+# terminal's 16 ANSI slots, which stylix themes from base16 elsewhere, so
+# LS_COLORS tracks the scheme without a stylix target here.
+{
+  lib,
+  pkgs,
+}: {
+  name = "nushell";
+  defaultPackage = "nushell";
+
+  options = {
+    configFile = lib.mkOption {
+      type = lib.types.path;
+      default = ./config.nu;
+      description = "Base config.nu baked into the wrapper and loaded via --config.";
+    };
+
+    extraConfig = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      description = "Extra nushell config appended to the baked config.nu.";
+    };
+
+    carapace.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Put carapace on the wrapper PATH; the baked config.nu external completer calls it.";
+    };
+
+    vivid = {
+      enable = lib.mkEnableOption "the vivid LS_COLORS hook in the baked env.nu";
+      package = lib.mkPackageOption pkgs "vivid" {};
+      theme = lib.mkOption {
+        type = lib.types.str;
+        default = "ansi";
+        example = "gruvbox-dark";
+        description = ''
+          vivid theme baked into env.nu as $env.LS_COLORS. Defaults to the
+          `ansi` theme, which renders file types through the terminal's 16
+          ANSI slots — stylix themes those from base16 (the same mapping the
+          ghostty target uses), so LS_COLORS tracks the scheme without pinning
+          a vivid colour theme.
+        '';
+      };
+    };
+
+    starship.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Emit `starship init nu` into the baked env.nu (writes to nushell's
+        vendor autoload dir, guarded on starship being on PATH). The starship
+        wrapper itself comes from my.starship.
+      '';
+    };
+  };
+
+  build = {
+    cfg,
+    pkgs,
+    lib,
+    ...
+  }: let
+    starshipEnvHook = ''
+      if (which starship | is-not-empty) {
+        mkdir ($nu.data-dir | path join "vendor/autoload")
+        ^starship init nu | save -f ($nu.data-dir | path join "vendor/autoload/starship.nu")
+      }
+    '';
+
+    vividEnvHook = ''
+      $env.LS_COLORS = (^vivid generate ${lib.escapeShellArg cfg.vivid.theme})
+    '';
+
+    configText =
+      builtins.readFile cfg.configFile
+      + lib.optionalString (cfg.extraConfig != "") "\n${cfg.extraConfig}\n";
+
+    envText =
+      lib.optionalString (cfg.vivid.enable && cfg.vivid.theme != "") vividEnvHook
+      + lib.optionalString cfg.starship.enable starshipEnvHook;
+
+    configFile = pkgs.writeText "config.nu" configText;
+    envFile = pkgs.writeText "env.nu" envText;
+  in
+    pkgs.mkWrapped {
+      pkg = cfg.package;
+      name = "nu";
+      flags = ["--config" "${configFile}" "--env-config" "${envFile}"];
+      extraPaths =
+        lib.optional cfg.carapace.enable pkgs.carapace
+        ++ lib.optional cfg.vivid.enable cfg.vivid.package;
+    };
+}

--- a/modules/my/programs/nvf/body.nix
+++ b/modules/my/programs/nvf/body.nix
@@ -1,0 +1,153 @@
+# The nvf module body fed to `lib.neovimConfiguration`. Ported from the old
+# modules/programs/nvf/config.nix `settings` body: the LSP/treesitter/telescope/
+# languages/keymaps block, the meta.nvim block (gated on cfg.meta.enable) and the
+# stylix polarity/base16 wiring (now driven by the my.* `theme` instead of the
+# ambient `config.stylix` + a separate stylix nvf target).
+#
+# `theme` is the framework's resolved theme (or null): `{ colors; polarity; ... }`
+# with base16 `colors` as base00..base0F hex WITHOUT a leading `#`. `cfg` is the
+# resolved my.nvf option set.
+{
+  cfg,
+  theme ? null,
+}: {
+  lib,
+  pkgs,
+  options,
+  ...
+}: let
+  hasTomlLanguage = lib.hasAttrByPath ["vim" "languages" "toml" "enable"] options;
+
+  themed = theme != null;
+  polarity =
+    if themed
+    then theme.polarity
+    else "dark";
+
+  # nvf's base16 theme wants `#`-prefixed hex; the framework hands base16
+  # `colors` without the `#`. Only wire it when the palette is actually present.
+  hasPalette = themed && (theme.colors or {}) != {};
+  base16Colors = lib.mapAttrs (_name: hex: "#${hex}") (theme.colors or {});
+in {
+  vim = lib.mkMerge [
+    (lib.mkIf themed {
+      luaConfigRC.background = lib.nvim.dag.entryBefore ["theme"] ''
+        vim.o.background = "${polarity}"
+      '';
+    })
+    # base16 palette from `theme.colors` via nvf's own base16 theme support.
+    # Replaces the removed per-app stylix nvf target that used to feed
+    # `programs.nvf.settings` with the scheme (#43/#38).
+    (lib.mkIf hasPalette {
+      theme = {
+        enable = true;
+        name = "base16";
+        base16-colors = base16Colors;
+      };
+    })
+    (lib.mkIf cfg.meta.enable {
+      luaConfigRC.meta-nvim = lib.nvim.dag.entryAfter ["telescope"] ''
+        local meta_plugin_path = "${cfg.meta.pluginPath}"
+        if vim.fn.isdirectory(meta_plugin_path) == 1 then
+          vim.opt.rtp:prepend(meta_plugin_path)
+          require("telescope").load_extension("myles")
+          require("telescope").load_extension("biggrep")
+          require("telescope").load_extension("hg")
+
+          local function in_arc_project()
+            return vim.fn.findfile(".arcconfig", ".;") ~= ""
+          end
+
+          vim.keymap.set("n", "<leader>ff", function()
+            if in_arc_project() then
+              require("telescope").extensions.myles.myles({})
+            else
+              require("telescope.builtin").find_files({})
+            end
+          end, { desc = "Find files" })
+
+          vim.keymap.set("n", "<leader>fg", function()
+            if in_arc_project() then
+              require("telescope").extensions.biggrep.s({})
+            else
+              require("telescope.builtin").live_grep({})
+            end
+          end, { desc = "Grep" })
+
+          vim.keymap.set("n", "<leader>fd", function()
+            if in_arc_project() then
+              require("telescope").extensions.hg.diff({})
+            end
+          end, { desc = "Hg diff hunks" })
+        else
+          vim.notify("meta.nvim: plugin path " .. meta_plugin_path .. " not found, skipping", vim.log.levels.WARN)
+        end
+      '';
+    })
+    {
+      autocomplete.blink-cmp.enable = true;
+      viAlias = true;
+      vimAlias = true;
+
+      keymaps = [
+        {
+          key = "-";
+          mode = "n";
+          action = "<cmd>Oil<CR>";
+          desc = "Open parent directory";
+        }
+      ];
+      lsp = {
+        enable = true;
+        formatOnSave = true;
+        servers = {
+          nil.init_options = {
+            nix.flake.autoArchive = true;
+          };
+        };
+      };
+      mini = {
+        icons.enable = true;
+      };
+      telescope = {
+        enable = true;
+        extensions = [
+          {
+            name = "fzf";
+            packages = [pkgs.vimPlugins.telescope-fzf-native-nvim];
+            setup = {fzf = {fuzzy = true;};};
+          }
+        ];
+      };
+      treesitter.enable = true;
+      options = {
+        tabstop = 2;
+        shiftwidth = 2;
+        softtabstop = 2;
+        expandtab = true;
+      };
+      diagnostics.config = {
+        virtual_text = false;
+        virtual_lines.current_line = true;
+      };
+      utility.oil-nvim.enable = true;
+      languages =
+        {
+          enableFormat = true;
+          enableTreesitter = true;
+          nix = {
+            enable = true;
+          };
+          markdown = {
+            enable = true;
+          };
+          nu.enable = true;
+          python.enable = true;
+          zig.enable = true;
+        }
+        // lib.optionalAttrs hasTomlLanguage {
+          toml.enable = true;
+        };
+    }
+  ];
+}

--- a/modules/my/programs/nvf/body.nix
+++ b/modules/my/programs/nvf/body.nix
@@ -1,12 +1,4 @@
-# The nvf module body fed to `lib.neovimConfiguration`. Ported from the old
-# modules/programs/nvf/config.nix `settings` body: the LSP/treesitter/telescope/
-# languages/keymaps block, the meta.nvim block (gated on cfg.meta.enable) and the
-# stylix polarity/base16 wiring (now driven by the my.* `theme` instead of the
-# ambient `config.stylix` + a separate stylix nvf target).
-#
-# `theme` is the framework's resolved theme (or null): `{ colors; polarity; ... }`
-# with base16 `colors` as base00..base0F hex WITHOUT a leading `#`. `cfg` is the
-# resolved my.nvf option set.
+# The nvf module body fed to `lib.neovimConfiguration`.
 {
   cfg,
   theme ? null,
@@ -24,8 +16,7 @@
     then theme.polarity
     else "dark";
 
-  # nvf's base16 theme wants `#`-prefixed hex; the framework hands base16
-  # `colors` without the `#`. Only wire it when the palette is actually present.
+  # nvf's base16 theme wants `#`-prefixed hex; the framework hands it without.
   hasPalette = themed && (theme.colors or {}) != {};
   base16Colors = lib.mapAttrs (_name: hex: "#${hex}") (theme.colors or {});
 in {
@@ -35,9 +26,6 @@ in {
         vim.o.background = "${polarity}"
       '';
     })
-    # base16 palette from `theme.colors` via nvf's own base16 theme support.
-    # Replaces the removed per-app stylix nvf target that used to feed
-    # `programs.nvf.settings` with the scheme (#43/#38).
     (lib.mkIf hasPalette {
       theme = {
         enable = true;

--- a/modules/my/programs/nvf/default.nix
+++ b/modules/my/programs/nvf/default.nix
@@ -1,13 +1,6 @@
-# nvf program definition. See ../CONTRACT.md.
-#
-# nvf is the special case in the my.* surface: it does NOT wrap one pkgs attr, so
-# it OMITS `defaultPackage` (no `package` option is added). Instead it builds a
-# wrapped neovim from nvf's per-channel `lib.neovimConfiguration` builder, which
-# arrives as the `neovimConfiguration` specialArg (set per-configuration in the
-# flake partitions). The whole nvf config is baked into the derivation.
-#
-# Self-contained: ./body.nix is the ported config body and ./package.nix is the
-# ported standalone builder, so the old modules/programs/nvf can be deleted.
+# nvf omits defaultPackage (no `package` option): it builds neovim from the
+# `neovimConfiguration` specialArg (set per-configuration in the flake partitions)
+# rather than wrapping one pkgs attr.
 {
   lib,
   pkgs,

--- a/modules/my/programs/nvf/default.nix
+++ b/modules/my/programs/nvf/default.nix
@@ -1,0 +1,72 @@
+# nvf program definition. See ../CONTRACT.md.
+#
+# nvf is the special case in the my.* surface: it does NOT wrap one pkgs attr, so
+# it OMITS `defaultPackage` (no `package` option is added). Instead it builds a
+# wrapped neovim from nvf's per-channel `lib.neovimConfiguration` builder, which
+# arrives as the `neovimConfiguration` specialArg (set per-configuration in the
+# flake partitions). The whole nvf config is baked into the derivation.
+#
+# Self-contained: ./body.nix is the ported config body and ./package.nix is the
+# ported standalone builder, so the old modules/programs/nvf can be deleted.
+{
+  lib,
+  pkgs,
+}: {
+  name = "nvf";
+  themeable = true;
+
+  options = {
+    meta = {
+      enable = lib.mkEnableOption "meta.nvim plugin (Myles, BigGrep, Hg, LSP, etc.)";
+
+      pluginPath = lib.mkOption {
+        type = lib.types.str;
+        default = "/usr/share/fb-editor-support/nvim";
+        description = "Path to the meta.nvim plugin directory.";
+      };
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.deferredModule;
+      default = {};
+      description = ''
+        Extra nvf module merged into the standalone build. Arbitrary `vim.*`
+        tweaks work; this wins over the baked body and theme via nvf's own merge.
+      '';
+    };
+  };
+
+  build = {
+    cfg,
+    pkgs,
+    lib,
+    theme ? null,
+    specialArgs ? {},
+    ...
+  }: let
+    neovimConfiguration = specialArgs.neovimConfiguration or null;
+    bodyModule = import ./body.nix {inherit cfg theme;};
+  in
+    import ./package.nix {
+      inherit pkgs neovimConfiguration;
+      modules = [
+        bodyModule
+        cfg.settings
+      ];
+    };
+
+  assertions = {
+    cfg,
+    specialArgs,
+    lib,
+  }: [
+    {
+      assertion = (specialArgs.neovimConfiguration or null) != null;
+      message = ''
+        my.nvf.enable requires the `neovimConfiguration` specialArg. Set it
+        per-configuration in the flake partition's default.nix:
+        specialArgs.neovimConfiguration = inputs.nvf-<channel>.lib.neovimConfiguration;
+      '';
+    }
+  ];
+}

--- a/modules/my/programs/nvf/package.nix
+++ b/modules/my/programs/nvf/package.nix
@@ -1,7 +1,3 @@
-# Generate a wrapped neovim package from nvf's standalone builder. Pure tooling:
-# given a host's `neovimConfiguration` (the nvf flake input differs per
-# partition, threaded in as a specialArg) and a list of nvf modules, return the
-# built `neovim` derivation. Ported from modules/programs/nvf/package.nix.
 {
   pkgs,
   neovimConfiguration,

--- a/modules/my/programs/nvf/package.nix
+++ b/modules/my/programs/nvf/package.nix
@@ -1,0 +1,13 @@
+# Generate a wrapped neovim package from nvf's standalone builder. Pure tooling:
+# given a host's `neovimConfiguration` (the nvf flake input differs per
+# partition, threaded in as a specialArg) and a list of nvf modules, return the
+# built `neovim` derivation. Ported from modules/programs/nvf/package.nix.
+{
+  pkgs,
+  neovimConfiguration,
+  modules,
+}:
+(neovimConfiguration {
+  inherit pkgs modules;
+})
+.neovim

--- a/modules/my/programs/rg.nix
+++ b/modules/my/programs/rg.nix
@@ -1,4 +1,3 @@
-# rg program definition. See ./CONTRACT.md.
 {
   lib,
   pkgs,

--- a/modules/my/programs/rg.nix
+++ b/modules/my/programs/rg.nix
@@ -1,0 +1,14 @@
+# rg program definition. See ./CONTRACT.md.
+{
+  lib,
+  pkgs,
+}: {
+  name = "rg";
+  defaultPackage = "ripgrep";
+
+  build = {
+    cfg,
+    ...
+  }:
+    cfg.package;
+}

--- a/modules/my/programs/starship.nix
+++ b/modules/my/programs/starship.nix
@@ -1,0 +1,34 @@
+# Program definition for starship. See ./CONTRACT.md.
+{
+  lib,
+  pkgs,
+}: let
+  tomlFormat = pkgs.formats.toml {};
+in {
+  name = "starship";
+  defaultPackage = "starship";
+
+  options = {
+    settings = lib.mkOption {
+      type = tomlFormat.type;
+      default = {};
+      example = {add_newline = false;};
+      description = ''
+        starship prompt config baked into this wrapper via STARSHIP_CONFIG. The
+        shell wrappers emit `starship init <shell>`; this option only pins the
+        config the wrapped binary reads.
+      '';
+    };
+  };
+
+  build = {
+    cfg,
+    pkgs,
+    ...
+  }:
+    pkgs.mkWrapped {
+      pkg = cfg.package;
+      name = "starship";
+      env.STARSHIP_CONFIG = tomlFormat.generate "starship.toml" cfg.settings;
+    };
+}

--- a/modules/my/programs/starship.nix
+++ b/modules/my/programs/starship.nix
@@ -1,4 +1,3 @@
-# Program definition for starship. See ./CONTRACT.md.
 {
   lib,
   pkgs,

--- a/modules/my/system-scope.nix
+++ b/modules/my/system-scope.nix
@@ -1,11 +1,13 @@
-# Shared NixOS + nix-darwin core for the my.* surface. Declares the system scope
-# (my.<tool> -> environment.systemPackages) and the per-user scope
-# (users.users.<n>.my.<tool> -> users.users.<n>.packages, cascading from the
-# system scope). Imported by ./nixos.nix and ./nix-darwin.nix.
+# Shared NixOS + nix-darwin core for the my.* surface. There are two parallel
+# scopes, built from the SAME per-scope helpers below:
 #
-# `neovimConfiguration` arrives as a specialArg (set per-configuration in the
-# flake partitions); it's null when unset, which is fine until a host enables
-# my.nvf. See ./programs/CONTRACT.md.
+#   - system scope:   my.<tool>            -> environment.systemPackages
+#   - per-user scope: users.users.<n>.my.<tool> -> users.users.<n>.packages,
+#                     with its options cascading from the system scope.
+#
+# Imported by ./nixos.nix and ./nix-darwin.nix. `neovimConfiguration` arrives as
+# a specialArg (set per-configuration in the flake partitions); null when unset,
+# fine until a host enables my.nvf. See ./programs/CONTRACT.md.
 {
   config,
   lib,
@@ -18,11 +20,11 @@
 
   specialArgs = {inherit neovimConfiguration;};
 
+  # The system scope's resolved stylix theme (base16 palette + polarity/etc).
   systemStylix =
     if config ? stylix
     then config.stylix
     else {};
-
   systemTheme = mkTheme {
     stylixCfg = systemStylix;
     colors =
@@ -31,49 +33,73 @@
       else {};
   };
 
-  # Capture the system-scope config for cascade inside the per-user submodule.
-  outerConfig = config;
+  # A user's resolved stylix theme, from the per-user stylix surface
+  # (modules/stylix/users), which itself defaults from the system stylix.
+  userTheme = userCfg:
+    mkTheme {
+      stylixCfg = userCfg.stylix or {};
+      colors = userCfg.stylix.colors or {};
+    };
 
-  # `finalPackage` is defined UNCONDITIONALLY (it's lazy, so a disabled tool
-  # never forces `build`). Gating it with `mkIf …enable` inside the `my`
-  # submodule would make the submodule's unmatched-definition check force the
-  # condition while computing the submodule → infinite recursion. Only the
-  # install (a top-level option) is gated on enable.
-  perUser = userArgs: {
+  # ── Per-scope helpers (used identically by both scopes) ──────────────────
+  # `scopeMy` is the scope's `my` config (config.my for system, userCfg.my for a
+  # user); `scopeTheme` its resolved stylix theme.
+
+  # `finalPackage` for every tool, my-shaped: { <tool> = { finalPackage = …; } }.
+  # UNCONDITIONAL (lazy) on purpose: a disabled tool never forces `build`. Gating
+  # it with `mkIf …enable` *inside* the `my` submodule would make the submodule's
+  # unmatched-definition check force the condition while computing the submodule
+  # → infinite recursion. Only the install (below) is gated on enable.
+  finalPackageDefs = scopeMy: scopeTheme:
+    lib.mapAttrs (toolName: def: {
+      finalPackage = buildTool {
+        inherit def specialArgs;
+        theme = themeFor def scopeMy scopeMy.${toolName} scopeTheme;
+        toolCfg = scopeMy.${toolName};
+      };
+    })
+    defs;
+
+  # The enabled tools' finalPackages in a scope — the list to install.
+  installFor = scopeMy:
+    lib.concatLists (lib.mapAttrsToList (toolName: _def:
+      lib.optional scopeMy.${toolName}.enable scopeMy.${toolName}.finalPackage)
+    defs);
+
+  # Assertions declared by the scope's enabled tools (e.g. nvf's specialArg).
+  assertionsFor = scopeMy:
+    lib.concatLists (lib.mapAttrsToList (toolName: def:
+      lib.optionals (scopeMy.${toolName}.enable && def ? assertions) (def.assertions {
+        inherit specialArgs lib;
+        cfg = scopeMy.${toolName};
+      }))
+    defs);
+
+  # Per-user options default-cascade from the system scope: every non-enable,
+  # non-finalPackage option as a per-leaf mkDefault (deep-merge; user wins).
+  # enable stays its own default (false) so a system-enabled tool doesn't fan a
+  # copy into every user. Read from the *system* `config.my`.
+  cascadeFromSystem =
+    lib.mapAttrs (toolName: _def:
+      recursiveMkDefault (removeAttrs config.my.${toolName} ["enable" "finalPackage"]))
+    defs;
+
+  # The submodule applied to EVERY users.users.<name> (wired as the type of
+  # options.users.users below). This is where the per-user scope lives.
+  perUser = userArgs: let
+    userCfg = userArgs.config;
+  in {
     options.my = lib.mkOption {
       type = myType;
       default = {};
     };
 
-    config = let
-      userCfg = userArgs.config;
-      userTheme = mkTheme {
-        stylixCfg = userCfg.stylix or {};
-        colors = userCfg.stylix.colors or {};
-      };
-    in
-      lib.mkMerge (
-        # cascade the my.stylix master toggle
-        [{my.stylix.enable = lib.mkDefault outerConfig.my.stylix.enable;}]
-        ++ lib.mapAttrsToList (
-          toolName: def: {
-            # cascade every non-enable/finalPackage option as per-leaf mkDefault
-            my.${toolName} =
-              recursiveMkDefault
-              (removeAttrs outerConfig.my.${toolName} ["enable" "finalPackage"])
-              // {
-                finalPackage = buildTool {
-                  inherit def specialArgs;
-                  theme = themeFor def userCfg.my userCfg.my.${toolName} userTheme;
-                  toolCfg = userCfg.my.${toolName};
-                };
-              };
-
-            packages = lib.optional userCfg.my.${toolName}.enable userCfg.my.${toolName}.finalPackage;
-          }
-        )
-        defs
-      );
+    config = lib.mkMerge [
+      {my = cascadeFromSystem;}
+      {my.stylix.enable = lib.mkDefault config.my.stylix.enable;}
+      {my = finalPackageDefs userCfg.my (userTheme userCfg);}
+      {packages = installFor userCfg.my;}
+    ];
   };
 in {
   options.my = lib.mkOption {
@@ -85,34 +111,12 @@ in {
     type = lib.types.attrsOf (lib.types.submodule perUser);
   };
 
-  config = lib.mkMerge (
-    [
-      {my.stylix.enable = lib.mkDefault (systemStylix.enable or false);}
-      {
-        my =
-          lib.mapAttrs (toolName: def: {
-            finalPackage = buildTool {
-              inherit def specialArgs;
-              theme = themeFor def config.my config.my.${toolName} systemTheme;
-              toolCfg = config.my.${toolName};
-            };
-          })
-          defs;
-      }
-      {
-        environment.systemPackages =
-          lib.concatLists (lib.mapAttrsToList (toolName: _def:
-            lib.optional config.my.${toolName}.enable config.my.${toolName}.finalPackage)
-          defs);
-
-        assertions =
-          lib.concatLists (lib.mapAttrsToList (toolName: def:
-            lib.optionals (config.my.${toolName}.enable && def ? assertions) (def.assertions {
-              inherit specialArgs lib;
-              cfg = config.my.${toolName};
-            }))
-          defs);
-      }
-    ]
-  );
+  config = lib.mkMerge [
+    {my.stylix.enable = lib.mkDefault (systemStylix.enable or false);}
+    {my = finalPackageDefs config.my systemTheme;}
+    {
+      environment.systemPackages = installFor config.my;
+      assertions = assertionsFor config.my;
+    }
+  ];
 }

--- a/modules/my/system-scope.nix
+++ b/modules/my/system-scope.nix
@@ -1,13 +1,6 @@
-# Shared NixOS + nix-darwin core for the my.* surface. There are two parallel
-# scopes, built from the SAME per-scope helpers below:
-#
-#   - system scope:   my.<tool>            -> environment.systemPackages
-#   - per-user scope: users.users.<n>.my.<tool> -> users.users.<n>.packages,
-#                     with its options cascading from the system scope.
-#
-# Imported by ./nixos.nix and ./nix-darwin.nix. `neovimConfiguration` arrives as
-# a specialArg (set per-configuration in the flake partitions); null when unset,
-# fine until a host enables my.nvf. See ./programs/CONTRACT.md.
+# Shared NixOS + nix-darwin core for my.*: the system scope
+# (my.<tool> -> environment.systemPackages) and the per-user scope
+# (users.users.<n>.my.<tool> -> users.users.<n>.packages, cascading from system).
 {
   config,
   lib,
@@ -20,7 +13,6 @@
 
   specialArgs = {inherit neovimConfiguration;};
 
-  # The system scope's resolved stylix theme (base16 palette + polarity/etc).
   systemStylix =
     if config ? stylix
     then config.stylix
@@ -33,23 +25,16 @@
       else {};
   };
 
-  # A user's resolved stylix theme, from the per-user stylix surface
-  # (modules/stylix/users), which itself defaults from the system stylix.
   userTheme = userCfg:
     mkTheme {
       stylixCfg = userCfg.stylix or {};
       colors = userCfg.stylix.colors or {};
     };
 
-  # ── Per-scope helpers (used identically by both scopes) ──────────────────
-  # `scopeMy` is the scope's `my` config (config.my for system, userCfg.my for a
-  # user); `scopeTheme` its resolved stylix theme.
-
-  # `finalPackage` for every tool, my-shaped: { <tool> = { finalPackage = …; } }.
-  # UNCONDITIONAL (lazy) on purpose: a disabled tool never forces `build`. Gating
-  # it with `mkIf …enable` *inside* the `my` submodule would make the submodule's
-  # unmatched-definition check force the condition while computing the submodule
-  # → infinite recursion. Only the install (below) is gated on enable.
+  # finalPackage is UNCONDITIONAL (lazy, so a disabled tool never forces build);
+  # gating it inside the `my` submodule makes the submodule's unmatched-def check
+  # force the condition while computing the submodule -> infinite recursion. Only
+  # the install (below) is gated on enable.
   finalPackageDefs = scopeMy: scopeTheme:
     lib.mapAttrs (toolName: def: {
       finalPackage = buildTool {
@@ -60,13 +45,11 @@
     })
     defs;
 
-  # The enabled tools' finalPackages in a scope — the list to install.
   installFor = scopeMy:
     lib.concatLists (lib.mapAttrsToList (toolName: _def:
       lib.optional scopeMy.${toolName}.enable scopeMy.${toolName}.finalPackage)
     defs);
 
-  # Assertions declared by the scope's enabled tools (e.g. nvf's specialArg).
   assertionsFor = scopeMy:
     lib.concatLists (lib.mapAttrsToList (toolName: def:
       lib.optionals (scopeMy.${toolName}.enable && def ? assertions) (def.assertions {
@@ -75,17 +58,12 @@
       }))
     defs);
 
-  # Per-user options default-cascade from the system scope: every non-enable,
-  # non-finalPackage option as a per-leaf mkDefault (deep-merge; user wins).
-  # enable stays its own default (false) so a system-enabled tool doesn't fan a
-  # copy into every user. Read from the *system* `config.my`.
   cascadeFromSystem =
     lib.mapAttrs (toolName: _def:
       recursiveMkDefault (removeAttrs config.my.${toolName} ["enable" "finalPackage"]))
     defs;
 
-  # The submodule applied to EVERY users.users.<name> (wired as the type of
-  # options.users.users below). This is where the per-user scope lives.
+  # The submodule type of every users.users.<n>: its config is the per-user scope.
   perUser = userArgs: let
     userCfg = userArgs.config;
   in {

--- a/modules/my/system-scope.nix
+++ b/modules/my/system-scope.nix
@@ -1,0 +1,118 @@
+# Shared NixOS + nix-darwin core for the my.* surface. Declares the system scope
+# (my.<tool> -> environment.systemPackages) and the per-user scope
+# (users.users.<n>.my.<tool> -> users.users.<n>.packages, cascading from the
+# system scope). Imported by ./nixos.nix and ./nix-darwin.nix.
+#
+# `neovimConfiguration` arrives as a specialArg (set per-configuration in the
+# flake partitions); it's null when unset, which is fine until a host enables
+# my.nvf. See ./programs/CONTRACT.md.
+{
+  config,
+  lib,
+  pkgs,
+  neovimConfiguration ? null,
+  ...
+}: let
+  my = import ./lib.nix {inherit lib pkgs;};
+  inherit (my) defs myType recursiveMkDefault mkTheme themeFor buildTool;
+
+  specialArgs = {inherit neovimConfiguration;};
+
+  systemStylix =
+    if config ? stylix
+    then config.stylix
+    else {};
+
+  systemTheme = mkTheme {
+    stylixCfg = systemStylix;
+    colors =
+      if (config ? lib && config.lib ? stylix && config.lib.stylix ? colors)
+      then lib.filterAttrs (_: lib.isString) config.lib.stylix.colors
+      else {};
+  };
+
+  # Capture the system-scope config for cascade inside the per-user submodule.
+  outerConfig = config;
+
+  # `finalPackage` is defined UNCONDITIONALLY (it's lazy, so a disabled tool
+  # never forces `build`). Gating it with `mkIf …enable` inside the `my`
+  # submodule would make the submodule's unmatched-definition check force the
+  # condition while computing the submodule → infinite recursion. Only the
+  # install (a top-level option) is gated on enable.
+  perUser = userArgs: {
+    options.my = lib.mkOption {
+      type = myType;
+      default = {};
+    };
+
+    config = let
+      userCfg = userArgs.config;
+      userTheme = mkTheme {
+        stylixCfg = userCfg.stylix or {};
+        colors = userCfg.stylix.colors or {};
+      };
+    in
+      lib.mkMerge (
+        # cascade the my.stylix master toggle
+        [{my.stylix.enable = lib.mkDefault outerConfig.my.stylix.enable;}]
+        ++ lib.mapAttrsToList (
+          toolName: def: {
+            # cascade every non-enable/finalPackage option as per-leaf mkDefault
+            my.${toolName} =
+              recursiveMkDefault
+              (removeAttrs outerConfig.my.${toolName} ["enable" "finalPackage"])
+              // {
+                finalPackage = buildTool {
+                  inherit def specialArgs;
+                  theme = themeFor def userCfg.my userCfg.my.${toolName} userTheme;
+                  toolCfg = userCfg.my.${toolName};
+                };
+              };
+
+            packages = lib.optional userCfg.my.${toolName}.enable userCfg.my.${toolName}.finalPackage;
+          }
+        )
+        defs
+      );
+  };
+in {
+  options.my = lib.mkOption {
+    type = myType;
+    default = {};
+  };
+
+  options.users.users = lib.mkOption {
+    type = lib.types.attrsOf (lib.types.submodule perUser);
+  };
+
+  config = lib.mkMerge (
+    [
+      {my.stylix.enable = lib.mkDefault (systemStylix.enable or false);}
+      {
+        my =
+          lib.mapAttrs (toolName: def: {
+            finalPackage = buildTool {
+              inherit def specialArgs;
+              theme = themeFor def config.my config.my.${toolName} systemTheme;
+              toolCfg = config.my.${toolName};
+            };
+          })
+          defs;
+      }
+      {
+        environment.systemPackages =
+          lib.concatLists (lib.mapAttrsToList (toolName: _def:
+            lib.optional config.my.${toolName}.enable config.my.${toolName}.finalPackage)
+          defs);
+
+        assertions =
+          lib.concatLists (lib.mapAttrsToList (toolName: def:
+            lib.optionals (config.my.${toolName}.enable && def ? assertions) (def.assertions {
+              inherit specialArgs lib;
+              cfg = config.my.${toolName};
+            }))
+          defs);
+      }
+    ]
+  );
+}

--- a/modules/my/tests/default.nix
+++ b/modules/my/tests/default.nix
@@ -1,6 +1,5 @@
 # Auto-registers every *.nix here (except this file) as a flake check named after
-# the file. Each is a `{pkgs, inputs ? null}` -> nixosTest. Merged into
-# perSystem.checks by modules/flake/nixos/default.nix.
+# the file. Each is a `{pkgs, inputs ? null}` -> nixosTest.
 {
   pkgs,
   inputs ? null,

--- a/modules/my/tests/default.nix
+++ b/modules/my/tests/default.nix
@@ -1,0 +1,17 @@
+# Auto-registers every *.nix here (except this file) as a flake check named after
+# the file. Each is a `{pkgs, inputs ? null}` -> nixosTest. Merged into
+# perSystem.checks by modules/flake/nixos/default.nix.
+{
+  pkgs,
+  inputs ? null,
+}: let
+  inherit (pkgs) lib;
+  isTest = name: type: type == "regular" && name != "default.nix" && lib.hasSuffix ".nix" name;
+  tests = lib.filterAttrs isTest (builtins.readDir ./.);
+in
+  lib.mapAttrs' (
+    name: _:
+      lib.nameValuePair (lib.removeSuffix ".nix" name)
+      (import (./. + "/${name}") {inherit pkgs inputs;})
+  )
+  tests

--- a/modules/my/tests/my-cascade-precedence.nix
+++ b/modules/my/tests/my-cascade-precedence.nix
@@ -1,8 +1,5 @@
-# Asserts the load-bearing cascade + PATH-precedence mechanics:
-#   - system my.jujutsu installs a system-wide wrapper (root sees it),
-#   - a per-user override deep-merges over the system settings (per-leaf
-#     mkDefault: user keeps system keys AND adds/overrides its own),
-#   - the per-user wrapper shadows the system one in that user's PATH.
+# Cascade + PATH precedence: a per-user override deep-merges over system settings
+# and the per-user wrapper shadows the system one in that user's PATH.
 {
   pkgs,
   inputs ? null,
@@ -40,11 +37,8 @@ in
           assert "per-user" in where, f"tester did not get the per-user wrapper: {where!r}"
 
       with subtest("per-user config deep-merges over system (cascade)"):
-          # inherited from the system scope
           assert machine.succeed("su -l tester -c 'jj config get sys-key.value'").strip() == "SYS"
-          # the user's own addition
           assert machine.succeed("su -l tester -c 'jj config get user-key.value'").strip() == "USER"
-          # the user wins on a shared key
           assert machine.succeed("su -l tester -c 'jj config get shared.value'").strip() == "USER"
     '';
   }

--- a/modules/my/tests/my-cascade-precedence.nix
+++ b/modules/my/tests/my-cascade-precedence.nix
@@ -1,0 +1,50 @@
+# Asserts the load-bearing cascade + PATH-precedence mechanics:
+#   - system my.jujutsu installs a system-wide wrapper (root sees it),
+#   - a per-user override deep-merges over the system settings (per-leaf
+#     mkDefault: user keeps system keys AND adds/overrides its own),
+#   - the per-user wrapper shadows the system one in that user's PATH.
+{
+  pkgs,
+  inputs ? null,
+}: let
+  pkgsWrapped = pkgs.extend (import ../../nixpkgs/overlays/mkWrapped.nix);
+in
+  pkgs.testers.nixosTest {
+    name = "my-cascade-precedence";
+
+    nodes.machine = {
+      nixpkgs.pkgs = pkgsWrapped;
+      imports = [../nixos.nix];
+
+      my.jujutsu.enable = true;
+      my.jujutsu.settings.sys-key.value = "SYS";
+      my.jujutsu.settings.shared.value = "SYS";
+
+      users.users.tester = {
+        isNormalUser = true;
+        my.jujutsu.enable = true;
+        my.jujutsu.settings.user-key.value = "USER";
+        my.jujutsu.settings.shared.value = "USER";
+      };
+    };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+
+      with subtest("root uses the system wrapper (system settings only)"):
+          assert machine.succeed("jj config get shared.value").strip() == "SYS"
+          machine.fail("jj config get user-key.value")
+
+      with subtest("the per-user wrapper shadows the system one in PATH"):
+          where = machine.succeed("su -l tester -c 'readlink -f $(command -v jj)'")
+          assert "per-user" in where, f"tester did not get the per-user wrapper: {where!r}"
+
+      with subtest("per-user config deep-merges over system (cascade)"):
+          # inherited from the system scope
+          assert machine.succeed("su -l tester -c 'jj config get sys-key.value'").strip() == "SYS"
+          # the user's own addition
+          assert machine.succeed("su -l tester -c 'jj config get user-key.value'").strip() == "USER"
+          # the user wins on a shared key
+          assert machine.succeed("su -l tester -c 'jj config get shared.value'").strip() == "USER"
+    '';
+  }

--- a/modules/my/tests/my-direnv-wrapper.nix
+++ b/modules/my/tests/my-direnv-wrapper.nix
@@ -1,6 +1,4 @@
-# Asserts the per-user plumbing: users.users.<n>.my.direnv.{enable,stdlib} ->
-# baked direnvrc in the DIRENV_CONFIG dir -> wrapped direnv. Sentinel-based, so it
-# never asserts a real default. The my.* port of the OLD native direnv module.
+# Per-user plumbing: my.direnv.{stdlib,settings} -> DIRENV_CONFIG dir -> wrapped direnv.
 {
   pkgs,
   inputs ? null,

--- a/modules/my/tests/my-direnv-wrapper.nix
+++ b/modules/my/tests/my-direnv-wrapper.nix
@@ -1,0 +1,54 @@
+# Asserts the per-user plumbing: users.users.<n>.my.direnv.{enable,stdlib} ->
+# baked direnvrc in the DIRENV_CONFIG dir -> wrapped direnv. Sentinel-based, so it
+# never asserts a real default. The my.* port of the OLD native direnv module.
+{
+  pkgs,
+  inputs ? null,
+}: let
+  sentinel = "my-direnv-wrapper-9c2e";
+  pkgsWrapped = pkgs.extend (import ../../nixpkgs/overlays/mkWrapped.nix);
+in
+  pkgs.testers.nixosTest {
+    name = "my-direnv-wrapper";
+
+    nodes.machine = {
+      nixpkgs.pkgs = pkgsWrapped;
+      imports = [../nixos.nix];
+
+      users.users.tester = {
+        isNormalUser = true;
+        my.direnv.enable = true;
+        my.direnv.stdlib = "# ${sentinel}\n";
+      };
+    };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+
+      direnv = machine.succeed(
+          "su -l tester -c 'readlink -f $(command -v direnv)'"
+      ).strip()
+
+      with subtest("the wrapped direnv is in the user's environment and runs"):
+          machine.succeed("su -l tester -c 'direnv version'")
+
+      with subtest("the wrapper pins DIRENV_CONFIG to a baked config dir"):
+          machine.succeed(f"grep -aq -- '--set DIRENV_CONFIG ' {direnv}")
+
+      config_dir = machine.succeed(
+          f"grep -aoE '/nix/store/[a-z0-9]{{32}}-my-direnv-config' {direnv} | head -n1"
+      ).strip()
+      assert config_dir, "no baked DIRENV_CONFIG dir found in the wrapper"
+
+      with subtest("the baked direnvrc carries the user's stdlib sentinel"):
+          machine.succeed(f"grep -aq '${sentinel}' {config_dir}/direnvrc")
+
+      with subtest("nix-direnv is sourced by default"):
+          machine.succeed(
+              f"grep -aq 'share/nix-direnv/direnvrc' {config_dir}/direnvrc"
+          )
+
+      with subtest("direnv.toml is present in the baked config dir"):
+          machine.succeed(f"test -e {config_dir}/direnv.toml")
+    '';
+  }

--- a/modules/my/tests/my-fish-wrapper.nix
+++ b/modules/my/tests/my-fish-wrapper.nix
@@ -1,7 +1,4 @@
-# Asserts the per-user plumbing: users.users.<n>.my.fish.{enable} +
-# my.fish.interactiveShellInit -> baked conf.d -> wrapped fish that sources it on
-# interactive start. Sentinel-based, so it never asserts a real default. Part of
-# the my.* foundation.
+# Per-user plumbing: my.fish.interactiveShellInit -> baked conf.d -> wrapped fish.
 {
   pkgs,
   inputs ? null,

--- a/modules/my/tests/my-fish-wrapper.nix
+++ b/modules/my/tests/my-fish-wrapper.nix
@@ -1,0 +1,38 @@
+# Asserts the per-user plumbing: users.users.<n>.my.fish.{enable} +
+# my.fish.interactiveShellInit -> baked conf.d -> wrapped fish that sources it on
+# interactive start. Sentinel-based, so it never asserts a real default. Part of
+# the my.* foundation.
+{
+  pkgs,
+  inputs ? null,
+}: let
+  sentinel = "my-fish-wrapper-9c4e";
+  pkgsWrapped = pkgs.extend (import ../../nixpkgs/overlays/mkWrapped.nix);
+in
+  pkgs.testers.nixosTest {
+    name = "my-fish-wrapper";
+
+    nodes.machine = {
+      nixpkgs.pkgs = pkgsWrapped;
+      imports = [../nixos.nix];
+
+      users.users.tester = {
+        isNormalUser = true;
+        my.fish.enable = true;
+        my.fish.interactiveShellInit = "set -gx MY_FISH_SENTINEL ${sentinel}";
+      };
+    };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+
+      with subtest("the wrapped fish is in the user's environment and runs"):
+          machine.succeed("su -l tester -c 'fish --version'")
+
+      with subtest("the wrapper sources the user's baked conf.d (interactiveShellInit)"):
+          got = machine.succeed(
+              "su -l tester -c 'fish -c \"echo $MY_FISH_SENTINEL\"'"
+          ).strip()
+          assert got == "${sentinel}", f"wrapper did not source baked conf.d: {got!r}"
+    '';
+  }

--- a/modules/my/tests/my-gh-wrapper.nix
+++ b/modules/my/tests/my-gh-wrapper.nix
@@ -1,0 +1,41 @@
+# Asserts the per-user plumbing: users.users.<n>.my.gh.{enable,settings} ->
+# GH_EDITOR baked into the wrapped gh, with GH_CONFIG_DIR deliberately left
+# alone so `gh auth login` keeps owning hosts.yml. Sentinel-based, so it never
+# asserts a real default. Part of the my.* foundation.
+{
+  pkgs,
+  inputs ? null,
+}: let
+  sentinel = "my-gh-wrapper-editor-4b1d";
+  pkgsWrapped = pkgs.extend (import ../../nixpkgs/overlays/mkWrapped.nix);
+in
+  pkgs.testers.nixosTest {
+    name = "my-gh-wrapper";
+
+    nodes.machine = {
+      nixpkgs.pkgs = pkgsWrapped;
+      imports = [../nixos.nix];
+
+      users.users.tester = {
+        isNormalUser = true;
+        my.gh.enable = true;
+        my.gh.settings.editor = sentinel;
+      };
+    };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+
+      gh = machine.succeed("su -l tester -c 'readlink -f $(command -v gh)'").strip()
+
+      with subtest("the wrapped gh is in the user's environment and runs"):
+          machine.succeed("su -l tester -c 'gh --version'")
+
+      with subtest("the wrapper pins settings.editor as GH_EDITOR"):
+          machine.succeed(f"grep -aq 'GH_EDITOR' {gh}")
+          machine.succeed(f"grep -aq '${sentinel}' {gh}")
+
+      with subtest("the wrapper leaves GH_CONFIG_DIR alone so gh auth login keeps owning hosts.yml"):
+          machine.fail(f"grep -aq 'GH_CONFIG_DIR' {gh}")
+    '';
+  }

--- a/modules/my/tests/my-gh-wrapper.nix
+++ b/modules/my/tests/my-gh-wrapper.nix
@@ -1,7 +1,4 @@
-# Asserts the per-user plumbing: users.users.<n>.my.gh.{enable,settings} ->
-# GH_EDITOR baked into the wrapped gh, with GH_CONFIG_DIR deliberately left
-# alone so `gh auth login` keeps owning hosts.yml. Sentinel-based, so it never
-# asserts a real default. Part of the my.* foundation.
+# Per-user plumbing: my.gh.settings.editor -> GH_EDITOR; GH_CONFIG_DIR untouched.
 {
   pkgs,
   inputs ? null,

--- a/modules/my/tests/my-ghostty-stylix.nix
+++ b/modules/my/tests/my-ghostty-stylix.nix
@@ -1,17 +1,11 @@
-# Asserts the per-user my.* stylix plumbing for ghostty: an arbitrary base16
-# palette fed through users.users.<n>.stylix.colors lands on the right ghostty
-# keys in the wrapper's baked --config-file, and `ghostty +validate-config`
-# accepts the injected theme. The my.* port of programs/tests/ghostty-stylix.nix.
+# Per-user stylix theming: users.users.<n>.stylix.colors -> ghostty --config-file.
 {
   pkgs,
   inputs ? null,
 }: let
   pkgsWrapped = pkgs.extend (import ../../nixpkgs/overlays/mkWrapped.nix);
 
-  # Arbitrary, mutually distinct base16 ids so each slot is greppable in the
-  # rendered ghostty config. The values are meaningless — the test only proves
-  # that whatever palette goes into stylix comes out the far side as ghostty
-  # colors.
+  # Arbitrary distinct base16 ids so each slot is greppable in the output.
   colors = {
     base00 = "010203";
     base01 = "040506";
@@ -38,9 +32,8 @@ in
       nixpkgs.pkgs = pkgsWrapped;
       imports = [
         ../nixos.nix
-        # only the per-user stylix OPTIONS surface (colors/polarity/…); NOT
-        # ../../stylix/users (whole dir), which pulls in the old hand-written
-        # ghostty stylix target that the framework theming replaces.
+        # the per-user stylix options surface only; not the whole ../../stylix/users
+        # dir, which pulls in the old ghostty target the framework theming replaces.
         ../../stylix/users/options.nix
       ];
 

--- a/modules/my/tests/my-ghostty-stylix.nix
+++ b/modules/my/tests/my-ghostty-stylix.nix
@@ -1,0 +1,85 @@
+# Asserts the per-user my.* stylix plumbing for ghostty: an arbitrary base16
+# palette fed through users.users.<n>.stylix.colors lands on the right ghostty
+# keys in the wrapper's baked --config-file, and `ghostty +validate-config`
+# accepts the injected theme. The my.* port of programs/tests/ghostty-stylix.nix.
+{
+  pkgs,
+  inputs ? null,
+}: let
+  pkgsWrapped = pkgs.extend (import ../../nixpkgs/overlays/mkWrapped.nix);
+
+  # Arbitrary, mutually distinct base16 ids so each slot is greppable in the
+  # rendered ghostty config. The values are meaningless — the test only proves
+  # that whatever palette goes into stylix comes out the far side as ghostty
+  # colors.
+  colors = {
+    base00 = "010203";
+    base01 = "040506";
+    base02 = "070809";
+    base03 = "0a0b0c";
+    base04 = "0d0e0f";
+    base05 = "101112";
+    base06 = "131415";
+    base07 = "161718";
+    base08 = "191a1b";
+    base09 = "1c1d1e";
+    base0A = "1f2021";
+    base0B = "222324";
+    base0C = "252627";
+    base0D = "28292a";
+    base0E = "2b2c2d";
+    base0F = "2e2f30";
+  };
+in
+  pkgs.testers.nixosTest {
+    name = "my-ghostty-stylix";
+
+    nodes.machine = {
+      nixpkgs.pkgs = pkgsWrapped;
+      imports = [
+        ../nixos.nix
+        # only the per-user stylix OPTIONS surface (colors/polarity/…); NOT
+        # ../../stylix/users (whole dir), which pulls in the old hand-written
+        # ghostty stylix target that the framework theming replaces.
+        ../../stylix/users/options.nix
+      ];
+
+      users.users.tester = {
+        isNormalUser = true;
+        stylix = {
+          enable = true;
+          inherit colors;
+        };
+        my.stylix.enable = true;
+        my.ghostty.enable = true;
+      };
+    };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+
+      ghostty = machine.succeed("su -l tester -c 'readlink -f $(command -v ghostty)'").strip()
+
+      with subtest("the wrapper injects a baked --config-file"):
+          machine.succeed(f"grep -aq -- '--config-file=' {ghostty}")
+
+      config = machine.succeed(
+          f"grep -aoE '/nix/store/[a-z0-9]{{32}}-ghostty-config' {ghostty} | head -n1"
+      ).strip()
+      assert config, "no baked ghostty config path found in the wrapper"
+
+      with subtest("stylix base16 ids land in the baked ghostty config"):
+          machine.succeed(f"grep -aq 'background = #${colors.base00}' {config}")
+          machine.succeed(f"grep -aq 'foreground = #${colors.base05}' {config}")
+          machine.succeed(f"grep -aq 'selection-background = #${colors.base02}' {config}")
+          # base16 → ansi: slot 1 = base08 (red), slot 4 = base0D (blue).
+          machine.succeed(f"grep -aq 'palette = 1=#${colors.base08}' {config}")
+          machine.succeed(f"grep -aq 'palette = 4=#${colors.base0D}' {config}")
+
+      with subtest("the wrapped ghostty launches and accepts the injected theme"):
+          # The wrapper prepends --config-file=<theme>, so validating with no
+          # explicit config exercises the injected palette end-to-end; ghostty
+          # exits non-zero on a malformed color/key.
+          machine.succeed("su -l tester -c 'ghostty +validate-config'")
+    '';
+  }

--- a/modules/my/tests/my-git-wrapper.nix
+++ b/modules/my/tests/my-git-wrapper.nix
@@ -1,7 +1,4 @@
-# Asserts the per-user plumbing: users.users.<n>.my.git.{enable,settings,lfs} ->
-# baked GIT_CONFIG_GLOBAL -> wrapped git, with git-lfs on the wrapper PATH and
-# its filter baked in. Sentinel-based, so it never asserts a real default. Part
-# of the my.* foundation.
+# Per-user plumbing: my.git.{settings,lfs} -> GIT_CONFIG_GLOBAL + git-lfs on PATH.
 {
   pkgs,
   inputs ? null,

--- a/modules/my/tests/my-git-wrapper.nix
+++ b/modules/my/tests/my-git-wrapper.nix
@@ -1,0 +1,51 @@
+# Asserts the per-user plumbing: users.users.<n>.my.git.{enable,settings,lfs} ->
+# baked GIT_CONFIG_GLOBAL -> wrapped git, with git-lfs on the wrapper PATH and
+# its filter baked in. Sentinel-based, so it never asserts a real default. Part
+# of the my.* foundation.
+{
+  pkgs,
+  inputs ? null,
+}: let
+  sentinel = "my-git-wrapper-9c2e";
+  pkgsWrapped = pkgs.extend (import ../../nixpkgs/overlays/mkWrapped.nix);
+in
+  pkgs.testers.nixosTest {
+    name = "my-git-wrapper";
+
+    nodes.machine = {
+      nixpkgs.pkgs = pkgsWrapped;
+      imports = [../nixos.nix];
+
+      users.users.tester = {
+        isNormalUser = true;
+        my.git.enable = true;
+        my.git.lfs.enable = true;
+        my.git.settings.wrapper.sentinel = sentinel;
+      };
+    };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+
+      with subtest("the wrapped git is in the user's environment and runs"):
+          machine.succeed("su -l tester -c 'git --version'")
+
+      with subtest("the wrapper loads the user's baked GIT_CONFIG_GLOBAL"):
+          got = machine.succeed(
+              "su -l tester -c 'git config --global --get wrapper.sentinel'"
+          ).strip()
+          assert got == "${sentinel}", f"wrapper did not load baked config: {got!r}"
+
+          got = machine.succeed(
+              "su -l tester -c 'GIT_CONFIG_GLOBAL=/dev/null git config --global --get wrapper.sentinel'"
+          ).strip()
+          assert got == "${sentinel}", f"wrapper did not pin GIT_CONFIG_GLOBAL: {got!r}"
+
+      with subtest("git-lfs rides on the wrapper PATH and its filter is baked in"):
+          machine.succeed("su -l tester -c 'git lfs version'")
+          required = machine.succeed(
+              "su -l tester -c 'git config --global --get filter.lfs.required'"
+          ).strip()
+          assert required == "true", f"lfs filter not baked: {required!r}"
+    '';
+  }

--- a/modules/my/tests/my-jujutsu-wrapper.nix
+++ b/modules/my/tests/my-jujutsu-wrapper.nix
@@ -1,0 +1,42 @@
+# Asserts the per-user plumbing: users.users.<n>.my.jujutsu.{enable,settings} ->
+# baked JJ_CONFIG -> wrapped jj. Sentinel-based, so it never asserts a real
+# default. Part of the my.* foundation.
+{
+  pkgs,
+  inputs ? null,
+}: let
+  sentinel = "my-jj-wrapper-7f3a";
+  pkgsWrapped = pkgs.extend (import ../../nixpkgs/overlays/mkWrapped.nix);
+in
+  pkgs.testers.nixosTest {
+    name = "my-jujutsu-wrapper";
+
+    nodes.machine = {
+      nixpkgs.pkgs = pkgsWrapped;
+      imports = [../nixos.nix];
+
+      users.users.tester = {
+        isNormalUser = true;
+        my.jujutsu.enable = true;
+        my.jujutsu.settings.test-sentinel.value = sentinel;
+      };
+    };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+
+      with subtest("the wrapped jj is in the user's environment and runs"):
+          machine.succeed("su -l tester -c 'jj --version'")
+
+      with subtest("the wrapper loads the user's baked JJ_CONFIG"):
+          got = machine.succeed(
+              "su -l tester -c 'jj config get test-sentinel.value'"
+          ).strip()
+          assert got == "${sentinel}", f"wrapper did not load baked config: {got!r}"
+
+          got = machine.succeed(
+              "su -l tester -c 'JJ_CONFIG=/dev/null jj config get test-sentinel.value'"
+          ).strip()
+          assert got == "${sentinel}", f"wrapper did not pin JJ_CONFIG: {got!r}"
+    '';
+  }

--- a/modules/my/tests/my-jujutsu-wrapper.nix
+++ b/modules/my/tests/my-jujutsu-wrapper.nix
@@ -1,6 +1,4 @@
-# Asserts the per-user plumbing: users.users.<n>.my.jujutsu.{enable,settings} ->
-# baked JJ_CONFIG -> wrapped jj. Sentinel-based, so it never asserts a real
-# default. Part of the my.* foundation.
+# Per-user plumbing: users.users.<n>.my.jujutsu.settings -> JJ_CONFIG -> jj.
 {
   pkgs,
   inputs ? null,

--- a/modules/my/tests/my-nushell-wrapper.nix
+++ b/modules/my/tests/my-nushell-wrapper.nix
@@ -1,8 +1,5 @@
-# Asserts the per-user plumbing: users.users.<n>.my.nushell.{enable,extraConfig,
-# vivid} -> baked config.nu (--config) + generated env.nu (--env-config) ->
-# wrapped nu, with vivid LS_COLORS, carapace on PATH, and the baked
-# `starship init nu` hook. Sentinel-based, so it never asserts a real default.
-# Part of the my.* foundation.
+# Per-user plumbing: my.nushell config.nu/env.nu -> wrapped nu, with vivid
+# LS_COLORS, carapace on PATH, and the baked `starship init nu` hook.
 {
   pkgs,
   inputs ? null,

--- a/modules/my/tests/my-nushell-wrapper.nix
+++ b/modules/my/tests/my-nushell-wrapper.nix
@@ -1,0 +1,63 @@
+# Asserts the per-user plumbing: users.users.<n>.my.nushell.{enable,extraConfig,
+# vivid} -> baked config.nu (--config) + generated env.nu (--env-config) ->
+# wrapped nu, with vivid LS_COLORS, carapace on PATH, and the baked
+# `starship init nu` hook. Sentinel-based, so it never asserts a real default.
+# Part of the my.* foundation.
+{
+  pkgs,
+  inputs ? null,
+}: let
+  sentinel = "my-nushell-wrapper-3e8b";
+  pkgsWrapped = pkgs.extend (import ../../nixpkgs/overlays/mkWrapped.nix);
+in
+  pkgs.testers.nixosTest {
+    name = "my-nushell-wrapper";
+
+    nodes.machine = {
+      nixpkgs.pkgs = pkgsWrapped;
+      imports = [../nixos.nix];
+
+      users.users.tester = {
+        isNormalUser = true;
+        my.nushell = {
+          enable = true;
+          extraConfig = ''
+            def __sentinel [] { "${sentinel}" }
+            def __lscolors_len [] { $env.LS_COLORS | str length }
+          '';
+          vivid.enable = true;
+        };
+      };
+    };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+
+      nu = machine.succeed("su -l tester -c 'readlink -f $(command -v nu)'").strip()
+
+      with subtest("the wrapped nu is in the user's environment and runs"):
+          machine.succeed("su -l tester -c 'nu --commands \"version\"'")
+
+      with subtest("the wrapper pins the baked config.nu via --config"):
+          got = machine.succeed(
+              "su -l tester -c 'nu --commands \"__sentinel\"'"
+          ).strip()
+          assert got == "${sentinel}", f"wrapper did not load baked config.nu: {got!r}"
+
+      with subtest("the baked env.nu sets vivid LS_COLORS and carapace is on PATH"):
+          # `$env.LS_COLORS` lives inside the baked config def, never on the
+          # `su -c` command line, so the login shell can't eat the `$`.
+          colors = machine.succeed(
+              "su -l tester -c 'nu --commands \"__lscolors_len\"'"
+          ).strip()
+          assert int(colors) > 0, f"vivid LS_COLORS not set in env.nu: {colors!r}"
+          machine.succeed("su -l tester -c 'nu --commands \"carapace --version\"'")
+
+      with subtest("the env.nu carries the starship init hook"):
+          env = machine.succeed(
+              f"grep -aoE '/nix/store/[a-z0-9]{{32}}-env.nu' {nu} | head -n1"
+          ).strip()
+          assert env, "no baked env.nu path found in the wrapper"
+          machine.succeed(f"grep -aq 'starship init nu' {env}")
+    '';
+  }

--- a/modules/my/tests/my-nvf-polarity.nix
+++ b/modules/my/tests/my-nvf-polarity.nix
@@ -1,0 +1,64 @@
+# Proves the standalone nvf build plumbing end-to-end through the my.* surface: a
+# sentinel stylix polarity comes out the far side as `vim.o.background` in the
+# wrapped neovim built by my.nvf. "light" is the sentinel (the default is
+# "dark"), so the test exercises the wiring rather than a default. The my.* port
+# of programs/tests/nvf-polarity.nix.
+#
+# nvf builds via the `neovimConfiguration` specialArg (not an option), so the
+# node sets it through `_module.args`. The system-scope `theme` is resolved from
+# the host's `config.stylix`; my.stylix.enable turns the integration on so the
+# polarity reaches the baked nvf body.
+{
+  pkgs,
+  inputs ? null,
+}:
+pkgs.testers.nixosTest {
+  name = "my-nvf-polarity";
+
+  nodes.machine = {lib, ...}: {
+    imports = [
+      ../nixos.nix
+    ];
+
+    # Minimal stylix stub so system-scope.nix's `config.stylix` read resolves a
+    # `theme` without pulling the whole stylix module into the test.
+    options.stylix = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+      };
+      polarity = lib.mkOption {
+        type = lib.types.str;
+        default = "dark";
+      };
+    };
+
+    config = {
+      # nvf builds via the `neovimConfiguration` specialArg (not an option); feed
+      # it as a module arg. Must live under `config` (a module with an explicit
+      # `options`/`config` can't also have bare top-level attributes).
+      _module.args.neovimConfiguration = inputs.nvf-nixos.lib.neovimConfiguration;
+
+      stylix = {
+        enable = true;
+        polarity = "light";
+      };
+      my.stylix.enable = true;
+      my.nvf.enable = true;
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("the standalone nvf build is the system nvim"):
+        machine.succeed("command -v nvim")
+        machine.succeed("nvim --version")
+
+    with subtest("the stylix polarity reaches vim.o.background"):
+        bg = machine.succeed(
+            "HOME=/root nvim --headless '+lua io.write(vim.o.background)' '+qa!' 2>&1"
+        ).strip()
+        assert bg == "light", f"expected background 'light', got {bg!r}"
+  '';
+}

--- a/modules/my/tests/my-nvf-polarity.nix
+++ b/modules/my/tests/my-nvf-polarity.nix
@@ -1,13 +1,5 @@
-# Proves the standalone nvf build plumbing end-to-end through the my.* surface: a
-# sentinel stylix polarity comes out the far side as `vim.o.background` in the
-# wrapped neovim built by my.nvf. "light" is the sentinel (the default is
-# "dark"), so the test exercises the wiring rather than a default. The my.* port
-# of programs/tests/nvf-polarity.nix.
-#
-# nvf builds via the `neovimConfiguration` specialArg (not an option), so the
-# node sets it through `_module.args`. The system-scope `theme` is resolved from
-# the host's `config.stylix`; my.stylix.enable turns the integration on so the
-# polarity reaches the baked nvf body.
+# nvf build plumbing: a stylix polarity comes out as `vim.o.background` in the
+# wrapped neovim built by my.nvf.
 {
   pkgs,
   inputs ? null,
@@ -20,8 +12,7 @@ pkgs.testers.nixosTest {
       ../nixos.nix
     ];
 
-    # Minimal stylix stub so system-scope.nix's `config.stylix` read resolves a
-    # `theme` without pulling the whole stylix module into the test.
+    # stylix stub so system-scope's `config.stylix` read resolves a theme.
     options.stylix = {
       enable = lib.mkOption {
         type = lib.types.bool;
@@ -34,9 +25,8 @@ pkgs.testers.nixosTest {
     };
 
     config = {
-      # nvf builds via the `neovimConfiguration` specialArg (not an option); feed
-      # it as a module arg. Must live under `config` (a module with an explicit
-      # `options`/`config` can't also have bare top-level attributes).
+      # the neovimConfiguration specialArg, fed as a module arg (must be under
+      # `config` since this module also declares `options`).
       _module.args.neovimConfiguration = inputs.nvf-nixos.lib.neovimConfiguration;
 
       stylix = {

--- a/modules/my/tests/my-starship-wrapper.nix
+++ b/modules/my/tests/my-starship-wrapper.nix
@@ -1,0 +1,44 @@
+# Asserts the per-user plumbing: users.users.<n>.my.starship.{enable,settings} ->
+# baked STARSHIP_CONFIG -> wrapped starship. Sentinel-based, so it never asserts
+# a real default. Part of the my.* foundation.
+{
+  pkgs,
+  inputs ? null,
+}: let
+  sentinel = "my-wrapper-prompt-6d4a";
+  pkgsWrapped = pkgs.extend (import ../../nixpkgs/overlays/mkWrapped.nix);
+in
+  pkgs.testers.nixosTest {
+    name = "my-starship-wrapper";
+
+    nodes.machine = {
+      nixpkgs.pkgs = pkgsWrapped;
+      imports = [../nixos.nix];
+
+      users.users.tester = {
+        isNormalUser = true;
+        my.starship.enable = true;
+        my.starship.settings.aws.symbol = sentinel;
+      };
+    };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+
+      starship = machine.succeed("su -l tester -c 'readlink -f $(command -v starship)'").strip()
+
+      with subtest("the wrapped starship is in the user's environment and runs"):
+          machine.succeed("su -l tester -c 'starship --version'")
+
+      with subtest("the wrapper pins the user's baked config via STARSHIP_CONFIG"):
+          machine.succeed(f"grep -aq 'STARSHIP_CONFIG' {starship}")
+          config = machine.succeed(
+              f"grep -aoE '/nix/store/[a-z0-9]{{32}}-starship.toml' {starship} | head -n1"
+          ).strip()
+          assert config, "no baked starship.toml path found in the wrapper"
+          machine.succeed(f"grep -aq '${sentinel}' {config}")
+
+      with subtest("the wrapped starship emits a shell init the wrappers can source"):
+          machine.succeed("su -l tester -c 'starship init fish'")
+    '';
+  }

--- a/modules/my/tests/my-starship-wrapper.nix
+++ b/modules/my/tests/my-starship-wrapper.nix
@@ -1,6 +1,4 @@
-# Asserts the per-user plumbing: users.users.<n>.my.starship.{enable,settings} ->
-# baked STARSHIP_CONFIG -> wrapped starship. Sentinel-based, so it never asserts
-# a real default. Part of the my.* foundation.
+# Per-user plumbing: my.starship.settings -> STARSHIP_CONFIG -> wrapped starship.
 {
   pkgs,
   inputs ? null,

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -8,5 +8,6 @@
     ./ephemeral-secrets.nix
     ./users.nix
     ../users
+    ../my/nixos.nix
   ];
 }


### PR DESCRIPTION
## Summary

Introduces `modules/my/` — a private `my.*` option namespace for installing **configured/wrapped packages**, replacing the `programs.<tool>` / `users.users.<n>.programs.<tool>` scheme with explicit system-vs-per-user semantics. Part of #36.

- **`my.<tool>.enable`** installs a wrapped package **system-wide** (all users).
- **`users.users.<n>.my.<tool>.enable`** installs it **for one user**, whose config **cascades from and deep-merges over** the system config (per-leaf `mkDefault`) and whose wrapper **PATH-shadows** the system one.
- `my.*` only configures + installs a package — never system state (shells, login shell, services).

## What's here

- **Framework:** `lib.nix` (shared submodule type, cascade, theme resolver, build/install helpers), `system-scope.nix` (shared NixOS + nix-darwin core), thin `nixos.nix` / `nix-darwin.nix`, and `home-manager.nix` (standalone-HM hosts). `programs/CONTRACT.md` is the frozen one-shape program-definition contract; `programs/default.nix` auto-discovers tool files/dirs.
- **11 programs:** jujutsu (reference), git, gh, fd, rg, starship, ghostty, nushell, fish, direnv, nvf.
- **Automatic per-package stylix theming:** `my.stylix.enable` (global) / `my.<tool>.stylix.enable` (per-tool), user settings win.
- **nvf** builds via a `neovimConfiguration` **specialArg** (not an option), with a guarded assertion when missing.
- **12 plumbing tests** under `modules/my/tests/`, including `my-cascade-precedence` for the deep-merge + PATH-shadow mechanics.

Wired into the flake but **disabled by default** — a no-op on every host until opted in.

## Verification

Eval-green: all host configs evaluate, every wrapper `finalPackage` builds, all `my-*` checks evaluate. (VM tests can only be *evaluated* on darwin — run `nix flake check` on Linux/CI to execute them.)

One real bug fixed during verification: the `my` submodule's unmatched-definition check forced `mkIf` conditions into an infinite recursion, so `finalPackage` is defined unconditionally (lazy) and only the install is gated.

## Deliberately deferred (follow-up)

Translating jasonbk's HM values, enabling tools per-host, deleting the old `modules/programs` & `modules/users`, and updating `docs/WRAPPERS.md`. The linked issues under #36 (#39, #40, #43–#57) have been rewritten to this convention.

## Caveats

- `my.fish` is a first cut (`conf.d` init + plugin vendor-path baking) with `TODO(#42)` for full vendor-completion parity.
- `my.nvf` base16 wiring is best-effort and not exercised by its test (polarity is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
