### PR TITLE
my.{retroarch,steam-rom-manager}: port gamer's gaming stack off home-manager (#49)

### DIFF
--- a/hosts/thebeast/home-manager/gamer/default.nix
+++ b/hosts/thebeast/home-manager/gamer/default.nix
@@ -1,73 +1,6 @@
-{
-  pkgs,
-  lib,
-  osConfig,
-  config,
-  ...
-}: let
-  cfg = osConfig.gaming;
-
-  retroarchSystems = builtins.filter (s: s.type == "retroarch") cfg.systems;
-  standaloneSystems = builtins.filter (s: s.type == "standalone") cfg.systems;
-
-  # Deduplicate standalone packages by name
-  uniqueStandalonePkgNames = lib.unique (map (s: s.pkg) standaloneSystems);
-
-  retroarchPkg = config.programs.retroarch.finalPackage;
-
-  # SRM parser generation
-  mkGlobPattern = exts: "\${title}@(${lib.concatMapStringsSep "|" (e: ".${e}") exts})";
-
-  mkParser = system: let
-    isRetroarch = system.type == "retroarch";
-    executablePath =
-      if isRetroarch
-      then "${retroarchPkg}/bin/retroarch"
-      else "${pkgs.${system.pkg}}/bin/${system.bin}";
-    cmdArgs =
-      if isRetroarch
-      then "-L ${retroarchPkg}/lib/retroarch/cores/${system.coreSo} \"\${filePath}\""
-      else "\"\${filePath}\"";
-  in {
-    parserType = "Glob";
-    configTitle = system.name;
-    steamCategory = system.name;
-    romDirectory = "${cfg.romDir}/${system.dir}";
-    steamDirectory = "\${steamdirglobal}";
-    startInDirectory = "";
-    executable = {
-      path = executablePath;
-      shortcutPassthrough = false;
-      appendArgsToExecutable = true;
-    };
-    commandLineArguments = cmdArgs;
-    parserInputs = {
-      glob = mkGlobPattern system.ext;
-    };
-    titleModifier = "\${fuzzyTitle}";
-    onlineImageQueries = "\${title}";
-    imageProviders = ["sgdb"];
-    imageProviderAPIs = {
-      sgdb = {
-        nsfw = false;
-        humor = false;
-        styles = [];
-        stylesHero = [];
-        stylesLogo = [];
-        stylesIcon = [];
-        imageMotionTypes = ["static"];
-      };
-    };
-    userAccounts = {
-      specifiedAccounts = "";
-    };
-    disabled = false;
-    drmProtect = false;
-    imagePool = "\${fuzzyTitle}";
-  };
-
-  parsers = map mkParser cfg.systems;
-in {
+# retroarch + steam-rom-manager moved to per-user my.* wrappers (#49) — see
+# hosts/thebeast/session/gaming-programs.nix.
+{...}: {
   home.stateVersion = "25.11";
 
   # Plasma's GTK Settings Sync already mirrors the active Plasma
@@ -78,22 +11,4 @@ in {
   # keeps the stylix palette on GTK apps without the fight. See
   # https://github.com/nix-community/stylix/issues/267
   stylix.targets.gtk.enable = false;
-
-  programs.retroarch = lib.mkIf (retroarchSystems != []) {
-    enable = true;
-    cores = lib.listToAttrs (map (s: lib.nameValuePair s.core {enable = true;}) retroarchSystems);
-    settings = {
-      video_driver = "vulkan";
-      config_save_on_exit = "false";
-    };
-  };
-
-  home.packages = lib.mkIf (cfg.systems != []) (
-    (map (p: pkgs.${p}) uniqueStandalonePkgNames)
-    ++ [pkgs.steam-rom-manager]
-  );
-
-  xdg.configFile."steam-rom-manager/userData/userConfigurations.json" = lib.mkIf (cfg.systems != []) {
-    text = builtins.toJSON parsers;
-  };
 }

--- a/hosts/thebeast/session/default.nix
+++ b/hosts/thebeast/session/default.nix
@@ -8,6 +8,7 @@
     ./decky.nix
     ./steam-theme.nix
     ./roms.nix
+    ./gaming-programs.nix
     ./omarchy.nix
   ];
 

--- a/hosts/thebeast/session/gaming-programs.nix
+++ b/hosts/thebeast/session/gaming-programs.nix
@@ -1,0 +1,38 @@
+# gamer's emulation stack as per-user my.* wrappers (#49), replacing the old
+# home-manager programs.retroarch + xdg.configFile SRM config: retroarch is
+# wrapped with the cores + settings below, and SRM's parser list is generated
+# from gaming.systems and seeded on first launch (seed-and-accept — SRM owns
+# its userData afterwards).
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.gaming;
+
+  retroarchSystems = builtins.filter (s: s.type == "retroarch") cfg.systems;
+  standalonePkgNames = lib.unique (map (s: s.pkg) (builtins.filter (s: s.type == "standalone") cfg.systems));
+in {
+  users.users.${cfg.user} = lib.mkIf (cfg.systems != []) {
+    my.retroarch = {
+      enable = true;
+      cores = lib.unique (map (s: s.core) retroarchSystems);
+      settings = {
+        video_driver = "vulkan";
+        config_save_on_exit = false;
+      };
+    };
+
+    my.steam-rom-manager = {
+      enable = true;
+      romDir = cfg.romDir;
+      systems = cfg.systems;
+      retroarchPackage = config.users.users.${cfg.user}.my.retroarch.finalPackage;
+    };
+
+    # Standalone emulators on gamer's profile so they're launchable outside
+    # the SRM-generated Steam shortcuts (which embed absolute store paths).
+    packages = map (p: pkgs.${p}) standalonePkgNames;
+  };
+}

--- a/modules/my/programs/retroarch.nix
+++ b/modules/my/programs/retroarch.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  pkgs,
+}: {
+  name = "retroarch";
+  # The bare package: only it carries the nixpkgs `wrapper` passthru that
+  # bakes cores + a declarative retroarch.cfg (pkgs.retroarch et al. are
+  # already-wrapped outputs without it).
+  defaultPackage = "retroarch-bare";
+
+  options = {
+    cores = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      example = ["nestopia" "snes9x"];
+      description = ''
+        libretro core names (attributes of `pkgs.libretro`) baked into the
+        wrapper. The cores' `.so` files land in the package's
+        `lib/retroarch/cores`, which the wrapped binary points at via `-L`.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.oneOf [lib.types.bool lib.types.int lib.types.float lib.types.str]);
+      default = {};
+      example = {
+        video_driver = "vulkan";
+        config_save_on_exit = false;
+      };
+      description = ''
+        retroarch.cfg entries baked into the wrapper via nixpkgs' declarative
+        `--appendconfig`, layered over the user's mutable
+        `~/.config/retroarch/retroarch.cfg` (which still owns everything else).
+        Appended entries are never written back by retroarch.
+      '';
+    };
+  };
+
+  build = {
+    cfg,
+    pkgs,
+    lib,
+    ...
+  }:
+    cfg.package.wrapper {
+      cores = map (name: pkgs.libretro.${name}) cfg.cores;
+      settings =
+        lib.mapAttrs (
+          _: value:
+            if lib.isBool value
+            then lib.boolToString value
+            else toString value
+        )
+        cfg.settings;
+    };
+}

--- a/modules/my/programs/steam-rom-manager.nix
+++ b/modules/my/programs/steam-rom-manager.nix
@@ -1,0 +1,188 @@
+{
+  lib,
+  pkgs,
+}: let
+  jsonFormat = pkgs.formats.json {};
+
+  systemModule = {
+    options = {
+      name = lib.mkOption {
+        type = lib.types.str;
+        example = "SNES";
+        description = "Display name; becomes the parser title and Steam category.";
+      };
+
+      type = lib.mkOption {
+        type = lib.types.enum ["retroarch" "standalone"];
+        description = "Whether the parser launches retroarch with a core or a standalone emulator.";
+      };
+
+      core = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "snes9x";
+        description = "libretro core name (pkgs.libretro attribute); unused here but carried so gaming.systems entries pass through verbatim.";
+      };
+
+      coreSo = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "snes9x_libretro.so";
+        description = "Core filename under retroarchPackage's lib/retroarch/cores, passed to retroarch via -L.";
+      };
+
+      pkg = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "dolphin-emu";
+        description = "nixpkgs attribute of the standalone emulator.";
+      };
+
+      bin = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        example = "dolphin-emu";
+        description = "Binary name under the standalone emulator's bin/.";
+      };
+
+      dir = lib.mkOption {
+        type = lib.types.str;
+        example = "snes";
+        description = "ROM subdirectory under romDir.";
+      };
+
+      ext = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        example = ["sfc" "smc" "zip"];
+        description = "ROM file extensions matched by the parser glob.";
+      };
+    };
+  };
+in {
+  name = "steam-rom-manager";
+  defaultPackage = "steam-rom-manager";
+
+  options = {
+    romDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/games/roms";
+      description = "Base ROM directory; each system parses romDir/<system.dir>.";
+    };
+
+    retroarchPackage = lib.mkOption {
+      type = lib.types.nullOr lib.types.package;
+      default = null;
+      example = lib.literalExpression "config.users.users.gamer.my.retroarch.finalPackage";
+      description = ''
+        retroarch wrapper whose bin/retroarch and lib/retroarch/cores back the
+        retroarch-type parsers. Required when `systems` has retroarch entries.
+      '';
+    };
+
+    systems = lib.mkOption {
+      type = lib.types.listOf (lib.types.submodule systemModule);
+      default = [];
+      description = ''
+        Emulation systems rendered into SRM parser configurations
+        (userConfigurations.json), one Glob parser per system. Shaped to accept
+        `config.gaming.systems` entries verbatim.
+      '';
+    };
+  };
+
+  assertions = {cfg, ...}: [
+    {
+      assertion = cfg.retroarchPackage != null || lib.all (s: s.type != "retroarch") cfg.systems;
+      message = "my.steam-rom-manager: `systems` has retroarch entries, so `retroarchPackage` must be set (e.g. to a my.retroarch finalPackage).";
+    }
+  ];
+
+  build = {
+    cfg,
+    pkgs,
+    lib,
+    ...
+  }: let
+    retroarchPkg =
+      assert lib.assertMsg (cfg.retroarchPackage != null)
+      "my.steam-rom-manager: `systems` has retroarch entries, so `retroarchPackage` must be set (e.g. to a my.retroarch finalPackage).";
+        cfg.retroarchPackage;
+
+    mkGlobPattern = exts: "\${title}@(${lib.concatMapStringsSep "|" (e: ".${e}") exts})";
+
+    mkParser = system: let
+      isRetroarch = system.type == "retroarch";
+      hasRequiredFields =
+        if isRetroarch
+        then
+          lib.assertMsg (system.coreSo != null)
+          "my.steam-rom-manager: retroarch system ${system.name} needs `coreSo`."
+        else
+          lib.assertMsg (system.pkg != null && system.bin != null)
+          "my.steam-rom-manager: standalone system ${system.name} needs `pkg` and `bin`.";
+      executablePath =
+        if isRetroarch
+        then "${retroarchPkg}/bin/retroarch"
+        else "${pkgs.${system.pkg}}/bin/${system.bin}";
+      cmdArgs =
+        if isRetroarch
+        then "-L ${retroarchPkg}/lib/retroarch/cores/${system.coreSo} \"\${filePath}\""
+        else "\"\${filePath}\"";
+    in
+      assert hasRequiredFields; {
+      parserType = "Glob";
+      configTitle = system.name;
+      steamCategory = system.name;
+      romDirectory = "${cfg.romDir}/${system.dir}";
+      steamDirectory = "\${steamdirglobal}";
+      startInDirectory = "";
+      executable = {
+        path = executablePath;
+        shortcutPassthrough = false;
+        appendArgsToExecutable = true;
+      };
+      commandLineArguments = cmdArgs;
+      parserInputs = {
+        glob = mkGlobPattern system.ext;
+      };
+      titleModifier = "\${fuzzyTitle}";
+      onlineImageQueries = "\${title}";
+      imageProviders = ["sgdb"];
+      imageProviderAPIs = {
+        sgdb = {
+          nsfw = false;
+          humor = false;
+          styles = [];
+          stylesHero = [];
+          stylesLogo = [];
+          stylesIcon = [];
+          imageMotionTypes = ["static"];
+        };
+      };
+      userAccounts = {
+        specifiedAccounts = "";
+      };
+      disabled = false;
+      drmProtect = false;
+      imagePool = "\${fuzzyTitle}";
+    };
+
+    seedFile = jsonFormat.generate "userConfigurations.json" (map mkParser cfg.systems);
+
+    # SRM rewrites its own userData at runtime, so the generated parser config
+    # is seed-and-accept: installed only when missing, then owned by SRM —
+    # never an immutable store symlink it would fail to write back.
+    seedUserConfigurations = ''
+      srm_userdata="''${XDG_CONFIG_HOME:-$HOME/.config}/steam-rom-manager/userData"
+      if [ ! -e "$srm_userdata/userConfigurations.json" ]; then
+        mkdir -p "$srm_userdata"
+        install -m 644 ${seedFile} "$srm_userdata/userConfigurations.json"
+      fi
+    '';
+  in
+    pkgs.mkWrapped {
+      pkg = cfg.package;
+      name = "steam-rom-manager";
+      run = lib.optional (cfg.systems != []) seedUserConfigurations;
+    };
+}

--- a/modules/my/tests/my-retroarch-wrapper.nix
+++ b/modules/my/tests/my-retroarch-wrapper.nix
@@ -1,0 +1,59 @@
+# Per-user plumbing: my.retroarch.{cores,settings} -> retroarch-with-cores
+# wrapper with the cores' .so files on -L and a baked declarative cfg.
+{
+  pkgs,
+  inputs ? null,
+}: let
+  pkgsWrapped = pkgs.extend (import ../../nixpkgs/overlays/mkWrapped.nix);
+in
+  pkgs.testers.nixosTest {
+    name = "my-retroarch-wrapper";
+
+    nodes.machine = {
+      nixpkgs.pkgs = pkgsWrapped;
+      imports = [../nixos.nix];
+
+      users.users.tester = {
+        isNormalUser = true;
+        my.retroarch = {
+          enable = true;
+          cores = ["nestopia"];
+          settings = {
+            video_driver = "vulkan";
+            config_save_on_exit = false;
+          };
+        };
+      };
+    };
+
+    testScript = {nodes, ...}: let
+      finalPackage = nodes.machine.users.users.tester.my.retroarch.finalPackage;
+    in ''
+      machine.wait_for_unit("multi-user.target")
+
+      with subtest("the wrapped retroarch is in the user's environment and runs"):
+          path = machine.succeed(
+              "su -l tester -c 'readlink -f \"$(command -v retroarch)\"'"
+          ).strip()
+          assert path.startswith("${finalPackage}"), f"retroarch resolves outside the wrapper: {path}"
+          machine.succeed("su -l tester -c 'retroarch --version'")
+
+      with subtest("the configured core is baked into the wrapper's cores dir"):
+          machine.succeed("test -e ${finalPackage}/lib/retroarch/cores/nestopia_libretro.so")
+
+      with subtest("the binary wrapper points -L at the baked cores dir"):
+          machine.succeed(
+              "grep -aq -- '-L ${finalPackage}/lib/retroarch/cores' ${finalPackage}/bin/retroarch"
+          )
+
+      with subtest("settings land in the baked declarative cfg, bools stringified"):
+          # Charset-restricted so the match can't greedily span the NUL
+          # separators between the C wrapper's embedded argv strings.
+          cfg_path = machine.succeed(
+              "grep -aoh '/nix/store/[A-Za-z0-9._+-]*-declarative-retroarch.cfg' ${finalPackage}/bin/retroarch | head -n1"
+          ).strip()
+          cfg = machine.succeed(f"cat {cfg_path}")
+          assert 'video_driver = "vulkan"' in cfg, f"video_driver not baked: {cfg!r}"
+          assert 'config_save_on_exit = "false"' in cfg, f"bool not stringified: {cfg!r}"
+    '';
+  }

--- a/modules/my/tests/my-steam-rom-manager-seed.nix
+++ b/modules/my/tests/my-steam-rom-manager-seed.nix
@@ -1,0 +1,96 @@
+# Per-user plumbing: my.steam-rom-manager.systems -> generated SRM parser
+# config, seeded into ~/.config on first launch and owned by SRM afterwards
+# (seed-and-accept: a relaunch must NOT clobber runtime edits).
+{
+  pkgs,
+  inputs ? null,
+}: let
+  pkgsWrapped = pkgs.extend (import ../../nixpkgs/overlays/mkWrapped.nix);
+  userConfigPath = ".config/steam-rom-manager/userData/userConfigurations.json";
+  # Electron handles --version before needing a display, so the wrapper's
+  # seed step runs and the app exits cleanly even headless.
+  launch = "su -l tester -c 'timeout 120 steam-rom-manager --version' >/dev/null 2>&1 || true";
+in
+  pkgs.testers.nixosTest {
+    name = "my-steam-rom-manager-seed";
+
+    nodes.machine = {config, ...}: {
+      nixpkgs.pkgs = pkgsWrapped;
+      imports = [../nixos.nix];
+
+      virtualisation.memorySize = 2048;
+
+      users.users.tester = {
+        isNormalUser = true;
+
+        my.retroarch = {
+          enable = true;
+          cores = ["nestopia"];
+        };
+
+        # Mirrors the thebeast wiring (hosts/thebeast/session/gaming-programs.nix):
+        # parser paths must point inside the user's own retroarch wrapper.
+        my.steam-rom-manager = {
+          enable = true;
+          romDir = "/games/roms";
+          retroarchPackage = config.users.users.tester.my.retroarch.finalPackage;
+          systems = [
+            {
+              name = "NES";
+              type = "retroarch";
+              core = "nestopia";
+              coreSo = "nestopia_libretro.so";
+              dir = "nes";
+              ext = ["nes" "zip"];
+            }
+            {
+              name = "Hello";
+              type = "standalone";
+              pkg = "hello";
+              bin = "hello";
+              dir = "hello";
+              ext = ["zip"];
+            }
+          ];
+        };
+      };
+    };
+
+    testScript = {nodes, ...}: let
+      retroarchPackage = nodes.machine.users.users.tester.my.retroarch.finalPackage;
+      jq = pkgs.lib.getExe pkgsWrapped.jq;
+    in ''
+      import json
+
+      machine.wait_for_unit("multi-user.target")
+
+      with subtest("first launch seeds userConfigurations.json"):
+          machine.fail("test -e /home/tester/${userConfigPath}")
+          machine.succeed("${launch}")
+          parsers = json.loads(machine.succeed("${jq} . /home/tester/${userConfigPath}"))
+
+      with subtest("the seeded parsers point at real emulator executables"):
+          by_title = {p["configTitle"]: p for p in parsers}
+          assert set(by_title) == {"NES", "Hello"}, f"unexpected parsers: {set(by_title)}"
+
+          nes = by_title["NES"]
+          assert nes["executable"]["path"] == "${retroarchPackage}/bin/retroarch", nes
+          core_so = "${retroarchPackage}/lib/retroarch/cores/nestopia_libretro.so"
+          assert core_so in nes["commandLineArguments"], nes["commandLineArguments"]
+          assert nes["romDirectory"] == "/games/roms/nes", nes["romDirectory"]
+          machine.succeed(f"test -x {nes['executable']['path']}")
+          machine.succeed(f"test -e {core_so}")
+          machine.succeed(f"test -x {by_title['Hello']['executable']['path']}")
+
+      with subtest("the seeded file is mutable and owned by the user"):
+          machine.succeed("su -l tester -c 'test -w ${userConfigPath}'")
+
+      with subtest("a relaunch does not clobber runtime edits (seed-and-accept)"):
+          machine.succeed(
+              "su -l tester -c \"echo '[]' > ${userConfigPath}\""
+          )
+          machine.succeed("${launch}")
+          kept = machine.succeed("cat /home/tester/${userConfigPath}").strip()
+          assert kept == "[]", f"relaunch clobbered the user's config: {kept!r}"
+    '';
+  }

--- a/modules/my/tests/omarchy-session-units.nix
+++ b/modules/my/tests/omarchy-session-units.nix
@@ -114,13 +114,32 @@ in
           machine.wait_until_succeeds(f"test -S {run_dir}/wayland-1")
           user("systemctl --user set-environment WAYLAND_DISPLAY=wayland-1")
 
-      with subtest("clipse and wl-clip-persist start and stay active"):
-          user("systemctl --user start clipse wl-clip-persist")
-          for svc in ("clipse", "wl-clip-persist"):
-              machine.wait_until_succeeds(
-                  f"su - tester -c 'export XDG_RUNTIME_DIR={run_dir}; "
-                  f"systemctl --user is-active {svc}'"
-              )
+      with subtest("clipse starts and stays active"):
+          user("systemctl --user start clipse")
+          machine.wait_until_succeeds(
+              f"su - tester -c 'export XDG_RUNTIME_DIR={run_dir}; "
+              "systemctl --user is-active clipse'"
+          )
+
+      with subtest("wl-clip-persist launches with the wayland env delivered"):
+          # Headless weston exposes no {ext,zwlr}-data-control global, so
+          # wl-clip-persist can never stay up here (under real Hyprland's
+          # wlroots protocols it does); it crash-loops into its start rate
+          # limit. Reaching the missing-protocol error proves the unit got
+          # WAYLAND_DISPLAY — failing to connect at all would mean it didn't.
+          machine.execute(
+              f"su - tester -c 'export XDG_RUNTIME_DIR={run_dir}; "
+              "systemctl --user start wl-clip-persist || true'"
+          )
+          # _UID instead of --user-unit: the user-unit match comes up empty in
+          # these test VMs (even as an explicit _SYSTEMD_USER_UNIT= field), so
+          # filter by uid and grep the syslog-identified lines.
+          machine.wait_until_succeeds(
+              f"journalctl _UID={uid} "
+              "| grep -q 'Failed to get clipboard manager'"
+          )
+          journal = machine.succeed(f"journalctl _UID={uid} | grep wl-clip-persist")
+          assert "Failed to connect to wayland server" not in journal, journal
 
       with subtest("hyprsunset is attempted with the right binary"):
           # hyprsunset speaks Hyprland-specific protocols, so under weston it
@@ -132,8 +151,11 @@ in
               f"su - tester -c 'export XDG_RUNTIME_DIR={run_dir}; "
               "systemctl --user start hyprsunset'"
           )
+          # grep for the unit name, not '.': --user-unit matches nothing in
+          # these VMs, and journalctl's literal "-- No entries --" output
+          # would satisfy a match-anything grep vacuously.
           machine.wait_until_succeeds(
-              f"journalctl --user-unit=hyprsunset _UID={uid} | grep -q ."
+              f"journalctl _UID={uid} | grep -q 'hyprsunset.service'"
           )
           state = user(
               "systemctl --user show -p ActiveState,SubState hyprsunset"
@@ -170,8 +192,15 @@ in
               "printf \"[Desktop Entry]\\nName=Hyprland (stub)\\nExec=stub-compositor\\nType=Application\\n\" "
               "> ~/.local/share/wayland-sessions/hyprland.desktop'"
           )
+          # uwsm >= 0.26 requires the login session identity (XDG_SESSION_ID/
+          # XDG_SEAT/XDG_VTNR) in `uwsm start`'s environment — production gets
+          # them from the display manager's PAM stack; without them the env
+          # preloader falls back to logind VT deduction, which has no session
+          # to find under this linger-only user manager and kills the graph.
           uwsm_user(
-              "systemd-run --user --unit=uwsm-session -- uwsm start hyprland.desktop"
+              "systemd-run --user --unit=uwsm-session "
+              "--setenv=XDG_SESSION_ID=1 --setenv=XDG_SEAT=seat0 --setenv=XDG_VTNR=1 "
+              "-- uwsm start hyprland.desktop"
           )
           machine.wait_until_succeeds(
               f"su - uwsmtester -c 'export XDG_RUNTIME_DIR={uwsm_run_dir}; "
@@ -179,29 +208,52 @@ in
               timeout=60,
           )
 
-          # The env race is the whole point: clipse and wl-clip-persist die
-          # instantly without WAYLAND_DISPLAY, so active + zero restarts
-          # means the activation environment carried the socket on the
-          # very first start. mako is the same but dbus-activated-capable.
           env = uwsm_user("systemctl --user show-environment")
           assert "WAYLAND_DISPLAY=wayland-uwsm" in env, (
               "uwsm finalize should have exported WAYLAND_DISPLAY:\n" + env
           )
-          for svc in ("clipse", "wl-clip-persist", "mako"):
+          machine.wait_until_succeeds(
+              f"su - uwsmtester -c 'export XDG_RUNTIME_DIR={uwsm_run_dir}; "
+              "systemctl --user is-active clipse'",
+              timeout=30,
+          )
+
+          # The env race is the whole point (issue #32), but headless weston
+          # can't keep the wlroots-protocol clients alive: wl-clip-persist
+          # needs a data-control global and mako needs zwlr_layer_shell_v1
+          # (both exist under real Hyprland). Each missing-protocol error
+          # still only happens once the client has already connected to
+          # WAYLAND_DISPLAY, so reaching it on the very first start — and
+          # never the connect-time error — proves the activation environment
+          # carried the socket from the start.
+          env_race_canaries = {
+              "wl-clip-persist": (
+                  "Failed to get clipboard manager",
+                  "Failed to connect to wayland server",
+              ),
+              "mako": (
+                  "compositor doesn't support zwlr_layer_shell_v1",
+                  "failed to connect to display",
+              ),
+          }
+          for svc, (protocol_err, connect_err) in env_race_canaries.items():
               machine.wait_until_succeeds(
-                  f"su - uwsmtester -c 'export XDG_RUNTIME_DIR={uwsm_run_dir}; "
-                  f"systemctl --user is-active {svc}'",
+                  f"journalctl _UID={uwsm_uid} | grep -q \"{protocol_err}\"",
                   timeout=30,
               )
-              n_restarts = uwsm_user(
-                  f"systemctl --user show -p NRestarts --value {svc}"
-              ).strip()
-              assert n_restarts == "0", (
-                  f"{svc} restarted {n_restarts} time(s) — it must come up "
-                  "first-try with WAYLAND_DISPLAY already present (issue #32)"
+              journal = machine.succeed(f"journalctl _UID={uwsm_uid} | grep {svc}")
+              assert connect_err not in journal, (
+                  f"{svc} started without WAYLAND_DISPLAY (issue #32):\n" + journal
               )
 
       with subtest("uwsm stop tears the omarchy units down with the session"):
+          # Stopping while session activation jobs are still queued is
+          # refused as a destructive transaction; let the graph settle.
+          machine.wait_until_succeeds(
+              f"su - uwsmtester -c 'export XDG_RUNTIME_DIR={uwsm_run_dir}; "
+              "systemctl --user list-jobs | grep -q \"No jobs\"'",
+              timeout=30,
+          )
           uwsm_user("uwsm stop")
           machine.wait_until_fails(
               f"su - uwsmtester -c 'export XDG_RUNTIME_DIR={uwsm_run_dir}; "

--- a/modules/nixpkgs/overlays/mkWrapped.nix
+++ b/modules/nixpkgs/overlays/mkWrapped.nix
@@ -4,6 +4,9 @@ final: _prev: {
     name ? pkg.meta.mainProgram or pkg.pname,
     env ? {},
     flags ? [],
+    # Shell snippets run by the wrapper before exec'ing pkg (makeWrapper
+    # --run), e.g. to seed mutable runtime state the program owns afterwards.
+    run ? [],
     extraPaths ? [],
     # Extra packages merged into the join alongside pkg (e.g. to contribute
     # share/ files). pkg stays first so its passthru/meta (shellPath, …) win.
@@ -18,6 +21,7 @@ final: _prev: {
           ${final.lib.concatStringsSep " \\\n      " (
           final.lib.mapAttrsToList (k: v: "--set ${k} ${final.lib.escapeShellArg "${v}"}") env
           ++ final.lib.optional (extraPaths != []) "--prefix PATH : ${final.lib.escapeShellArg (final.lib.makeBinPath extraPaths)}"
+          ++ map (r: "--run ${final.lib.escapeShellArg r}") run
           ++ map (f: "--add-flags ${final.lib.escapeShellArg f}") flags
         )}
       '';


### PR DESCRIPTION
Closes #49.

## What

- **`modules/my/programs/retroarch.nix`** — `build` returns nixpkgs' `retroarch-bare.wrapper { cores, settings }`: cores resolved from `pkgs.libretro.*` names land in `lib/retroarch/cores` (with `-L` baked into the binary wrapper), settings become a declarative `--appendconfig` retroarch.cfg. The user's `~/.config/retroarch/retroarch.cfg` stays mutable; appended settings win and are never written back (`config_save_on_exit = false`).
- **`modules/my/programs/steam-rom-manager.nix`** — generates `userConfigurations.json` (one Glob parser per system, retroarch parsers pointing at `retroarchPackage`'s `bin/retroarch` + core `.so`s, standalone parsers at the emulator's store path) and **seeds** it on first launch via a new `run` hook on `mkWrapped`. Seed-and-accept per the issue's carve-out: SRM rewrites its own userData at runtime, so the wrapper installs the file only when missing and SRM owns it afterwards.
- **`hosts/thebeast/session/gaming-programs.nix`** — wires `users.users.gamer.my.{retroarch,steam-rom-manager}` from `config.gaming.systems` (cores, romDir, parser list) and keeps the standalone emulators on gamer's profile. The old HM gamer config shrinks to `stateVersion` + the GTK/stylix carve-out.

The generated parser JSON is content-equivalent to what the HM module produced, with paths now pointing at the per-user `retroarch-with-cores` wrapper.

## VM tests

- **`my-retroarch-wrapper`** — wrapper resolves on the user's PATH, core `.so` baked, `-L` points at the baked cores dir, settings (incl. bool stringification) land in the declarative cfg.
- **`my-steam-rom-manager-seed`** — first launch seeds `userConfigurations.json`; parser executables/cores exist on disk; the seeded file is user-writable; **a relaunch does not clobber runtime edits** (the issue's "verify it doesn't clobber on launch").

## Bonus: deflaked `omarchy-session-units` (the `nix flake check` hang)

The endless `pam_unix(su:session)` lines were its 900s `wait_until_succeeds` polls. Four pre-existing bugs fixed (second commit):

1. uwsm 0.26's env preloader needs the login session identity (`XDG_SESSION_ID`/`XDG_SEAT`) and otherwise asks logind for the foreground-VT session — which doesn't exist under the linger-only test manager, killing the session graph. The test now passes those vars to `uwsm start`, as SDDM's PAM stack does in production.
2. `wl-clip-persist` (data-control) and `mako` (`zwlr_layer_shell_v1`) need wlroots protocols headless weston doesn't offer, so "is-active" could only pass by racing the restart-rate limit (hence flaky/hanging). They now assert the journal's missing-protocol error, which only occurs *after* connecting to `WAYLAND_DISPLAY` — still proving the issue #32 first-try env delivery.
3. `journalctl --user-unit` matches nothing in these VMs; the hyprsunset wait passed vacuously (`grep -q .` matched `-- No entries --`). Switched to `_UID=` filters with real patterns.
4. `uwsm stop` raced queued portal start jobs (destructive-transaction refusal); the test now lets the job queue settle first.

## Test plan

- `nix flake check` — green end to end (all 30 checks; previously hung/failed on `omarchy-session-units`).
- `omarchy-session-units` test script now finishes in ~25s.
- thebeast evals: gamer's profile gets `retroarch-with-cores` (8 cores from `gaming.systems`), the wrapped SRM, dolphin-emu, pcsx2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)