### PR TITLE
ssh-agent-switcher: make it a machine-lifetime system service

### DIFF
--- a/hosts/brutus/services/ssh-agent-switcher.nix
+++ b/hosts/brutus/services/ssh-agent-switcher.nix
@@ -1,5 +1,5 @@
 # brutus is a zmx host: sessions live here and clients reconnect, so the stable
 # agent socket (not sshd's per-connection one) is what zmx shells must see.
 {...}: {
-  services.ssh-agent-switcher.enable = true;
+  services.ssh-agent-switcher.users = ["jasonbk"];
 }

--- a/hosts/litus/services/ssh-agent-switcher.nix
+++ b/hosts/litus/services/ssh-agent-switcher.nix
@@ -1,5 +1,5 @@
 # litus is a zmx host: sessions live here and clients reconnect, so the stable
 # agent socket (not sshd's per-connection one) is what zmx shells must see.
 {...}: {
-  services.ssh-agent-switcher.enable = true;
+  services.ssh-agent-switcher.users = ["jasonbk"];
 }

--- a/modules/nixos/services/ssh-agent-switcher.nix
+++ b/modules/nixos/services/ssh-agent-switcher.nix
@@ -1,7 +1,16 @@
 # System-layer replacement for the old home-manager ssh-agent-switcher module
-# (issue #46): a per-user systemd user service plus a PAM-level SSH_AUTH_SOCK
-# export, so every login session (shell or sshd) sees the stable socket instead
-# of the per-connection one sshd hands out.
+# (issue #46): a per-user *system* service plus a PAM-level SSH_AUTH_SOCK export,
+# so the stable socket outlives any single login session and every shell/zmx
+# session — new or long-parked — sees the freshest forwarded agent.
+#
+# A system service (not systemd.user) keeps the daemon machine-lifetime: it
+# starts at boot, survives logout and `nixos-rebuild switch`, and needs no
+# user-manager lingering. User services are pulled by default.target, which is
+# activated once when the user manager first starts — a new login never
+# re-evaluates its wants, so a daemon that died (e.g. across a switch) stays
+# dead. The system service sidesteps that lifecycle entirely. It still runs as
+# the target user (User=%i) so it can read that user's forwarded agent sockets
+# (~/.ssh/agent, /tmp) and own the listening socket with the right permissions.
 {
   config,
   lib,
@@ -12,44 +21,65 @@
 in {
   # Upstream's module starts the daemon from environment.loginShellInit, which
   # only bash/zsh login shells source — the my.fish wrapper's preinit
-  # (modules/my/fish-system.nix) sources setEnvironment alone, so on hosts
-  # whose login shell is that wrapper the daemon would never start. A
-  # supervised systemd user service + sessionVariables export (both reach
-  # every session type) replaces it under the same option names.
+  # (modules/my/fish-system.nix) sources setEnvironment alone, so on hosts whose
+  # login shell is that wrapper the daemon would never start. A supervised
+  # service + sessionVariables export (both reach every session type) replaces
+  # it under the same option namespace.
   disabledModules = ["services/security/ssh-agent-switcher.nix"];
 
   options.services.ssh-agent-switcher = {
-    enable = lib.mkEnableOption "ssh-agent-switcher (stable SSH_AUTH_SOCK across reconnects and concurrent clients)";
+    users = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [];
+      example = ["jasonbk"];
+      description = ''
+        Users to run an ssh-agent-switcher instance for. Each gets a
+        machine-lifetime system service (an instance of the
+        `ssh-agent-switcher@` template) running as that user, listening on a
+        stable per-user socket that is exported as `SSH_AUTH_SOCK`. The empty
+        list disables the module.
+      '';
+    };
 
     package = lib.mkPackageOption pkgs "ssh-agent-switcher" {};
 
     socketPath = lib.mkOption {
       type = lib.types.str;
-      default = "/tmp/ssh-agent.%u";
+      default = "/tmp/ssh-agent.%i";
       description = ''
-        Stable socket the per-user daemon listens on, using systemd unit
-        specifiers (%u is the user name). Exported as SSH_AUTH_SOCK with %u
-        rendered as $USER, which both PAM and the shell setEnvironment
-        expand per user.
+        Stable socket each per-user daemon listens on, using systemd unit
+        specifiers (%i is the instance name = the user). Exported as
+        `SSH_AUTH_SOCK` with %i rendered as `$USER`, which both PAM and the
+        shell setEnvironment expand per user. Kept under /tmp (not
+        /run/user/%U) deliberately, so it does not depend on the user's logind
+        runtime dir.
       '';
     };
   };
 
-  config = lib.mkIf cfg.enable {
+  config = lib.mkIf (cfg.users != []) {
     environment.systemPackages = [cfg.package];
 
-    systemd.user.services.ssh-agent-switcher = {
-      description = "SSH agent switcher (proxies SSH_AUTH_SOCK to the freshest live forwarded agent socket)";
-      wantedBy = ["default.target"];
+    systemd.services."ssh-agent-switcher@" = {
+      description = "SSH agent switcher for %i (proxies SSH_AUTH_SOCK to the freshest live forwarded agent socket)";
       serviceConfig = {
+        User = "%i";
         ExecStartPre = "${lib.getExe' pkgs.coreutils "rm"} -f ${cfg.socketPath}";
         ExecStart = "${lib.getExe cfg.package} --socket-path=${cfg.socketPath}";
-        Restart = "on-failure";
+        # always (not on-failure): the proxy must self-heal even on a clean
+        # exit, so a stray SIGTERM never leaves the host without an agent socket.
+        Restart = "always";
         RestartSec = 5;
       };
     };
 
+    # Instantiate (and boot-start) one daemon per configured user. A template
+    # unit cannot carry its own wantedBy, so the instances are wanted by the
+    # boot target instead.
+    systemd.targets.multi-user.wants =
+      map (u: "ssh-agent-switcher@${u}.service") cfg.users;
+
     environment.sessionVariables.SSH_AUTH_SOCK =
-      lib.replaceStrings ["%u"] ["$USER"] cfg.socketPath;
+      lib.replaceStrings ["%i"] ["$USER"] cfg.socketPath;
   };
 }

--- a/modules/nixos/tests/ssh-agent-switcher.nix
+++ b/modules/nixos/tests/ssh-agent-switcher.nix
@@ -13,7 +13,7 @@ pkgs.testers.nixosTest {
   nodes.machine = {
     imports = [../services/ssh-agent-switcher.nix];
 
-    services.ssh-agent-switcher.enable = true;
+    services.ssh-agent-switcher.users = ["tester"];
     services.openssh.enable = true;
 
     users.users.tester.isNormalUser = true;
@@ -22,6 +22,13 @@ pkgs.testers.nixosTest {
   testScript = ''
     machine.wait_for_unit("multi-user.target")
     machine.wait_for_unit("sshd.service")
+
+    with subtest("it is a machine-lifetime system service: socket up before any login"):
+        # The instance is wanted by multi-user.target, so it is already active
+        # with its socket present before tester has ever logged in — proving the
+        # daemon is not scoped to a login session (the user-service regression).
+        machine.wait_for_unit("ssh-agent-switcher@tester.service")
+        machine.succeed("test -S /tmp/ssh-agent.tester")
 
     machine.succeed('ssh-keygen -t ed25519 -N "" -f /root/key')
     machine.succeed(
@@ -55,5 +62,15 @@ pkgs.testers.nixosTest {
         assert "ED25519" in out and "SOCK=/tmp/ssh-agent.tester" in out, (
             f"stable socket broke across reconnect: {out!r}"
         )
+
+    with subtest("the daemon self-heals on a clean kill (Restart=always)"):
+        # SIGTERM exits the daemon cleanly; only Restart=always (not on-failure)
+        # brings it back. This is the regression that left the host without an
+        # agent socket after a stray stop.
+        machine.succeed("rm -f /tmp/ssh-agent.tester")
+        machine.succeed("systemctl kill --signal=SIGTERM ssh-agent-switcher@tester.service")
+        machine.wait_until_succeeds("test -S /tmp/ssh-agent.tester")
+        out = machine.succeed(ssh + " \"bash -lc 'ssh-add -l'\"")
+        assert "ED25519" in out, f"agent unreachable after self-heal: {out!r}"
   '';
 }


### PR DESCRIPTION
## Problem

On litus (headless zmx host) `git`/ssh started failing with `Permission denied (publickey)` after a `nixos-rebuild switch`. Root cause: `ssh-agent-switcher` was a systemd **user** service wanted by `default.target`.

- `default.target` is activated **once**, when the user manager first starts (first login). A later login never re-evaluates its wants.
- So when the daemon died across the switch, it stayed dead — new SSH sessions never revived it — and `Restart=on-failure` ignored the *clean* exit.
- Result: no `/tmp/ssh-agent.$USER` socket, no `SSH_AUTH_SOCK`, auth fails until a manual `systemctl --user restart`.

## Fix

Nothing about the daemon is genuinely session-scoped — its listening socket is in `/tmp` (not `/run/user/%U`), it runs foreground with no pid file, and it only reads the user's forwarded agent sockets (`~/.ssh/agent`, `/tmp`). So lift it to the system layer:

- a templated **`ssh-agent-switcher@.service`** running as `User=%i`, wanted by `multi-user.target` — starts at boot, survives logout and `nixos-rebuild switch`, needs no user-manager lingering, and is up *before any session exists*
- **`Restart=always`** (not `on-failure`) so it self-heals even on a clean exit
- the option becomes **`users`** (the list to instantiate for), replacing the bare `enable`; litus and brutus set `users = ["jasonbk"]`

`environment.sessionVariables.SSH_AUTH_SOCK` is unchanged — already system-layer and correct.

## Tests

The VM test (`modules/nixos/tests/ssh-agent-switcher.nix`) gains two subtests for exactly the guarantees this adds:
- the socket is present **before any login** (machine-lifetime, not session-scoped)
- the daemon **self-heals after SIGTERM** (`Restart=always`)

Existing SSH_AUTH_SOCK / forwarded-agent / reconnect subtests are unchanged.

## Verify
- `nix build .#checks.x86_64-linux.ssh-agent-switcher` — passes (incl. new subtests)
- litus and brutus eval clean; `ssh-agent-switcher@jasonbk.service` wired into `multi-user.target.wants`
- alejandra formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)