### PR TITLE
brutus: drop home-manager, finish the my.* cutover

### DIFF
--- a/hosts/brutus/default.nix
+++ b/hosts/brutus/default.nix
@@ -1,6 +1,5 @@
 {...}: {
   imports = [
-    ./home-manager
     ./nixarr
     ./power
     ./services

--- a/hosts/brutus/home-manager/default.nix
+++ b/hosts/brutus/home-manager/default.nix
@@ -1,5 +1,0 @@
-{...}: {
-  home-manager.users.jasonbk.imports = [
-    ./jasonbk
-  ];
-}

--- a/hosts/brutus/home-manager/jasonbk/default.nix
+++ b/hosts/brutus/home-manager/jasonbk/default.nix
@@ -1,3 +1,0 @@
-{...}: {
-  home.stateVersion = "25.05";
-}

--- a/hosts/brutus/my.nix
+++ b/hosts/brutus/my.nix
@@ -109,15 +109,4 @@
   # programs.fish system integration + /etc/shells registration is wired by
   # modules/my/nixos.nix.
   users.users.jasonbk.shell = lib.mkForce config.my.fish.finalPackage;
-
-  # Old home-manager program paths, superseded by my.* above.
-  home-manager.users.jasonbk.programs = {
-    git.enable = lib.mkForce false;
-    jujutsu.enable = lib.mkForce false;
-    starship.enable = lib.mkForce false;
-    gh.enable = lib.mkForce false;
-    nushell.enable = lib.mkForce false;
-    fish.enable = lib.mkForce false;
-    direnv.enable = lib.mkForce false;
-  };
 }

--- a/modules/flake/nixos/default.nix
+++ b/modules/flake/nixos/default.nix
@@ -33,7 +33,6 @@
             ../../../hosts/brutus
             inputs.agenix.nixosModules.default
             inputs.determinate.nixosModules.default
-            inputs.home-manager-nixos.nixosModules.home-manager
             inputs.stylix-nixos.nixosModules.stylix
           ];
         };


### PR DESCRIPTION
Closes #52. Order 2 of 7 in the host-cutover matrix (#36), mirroring the thebeast cutover (#79).

brutus already routed every dev tool through the `my.*` wrappers (`git`/`jujutsu`/`gh`, the shells, nvf, claude-code, zmx, …), coexisting with the old home-manager program modules behind `mkForce false`. With the wrappers proven, this retires home-manager on the host.

## Changes
- Drop `inputs.home-manager-nixos.nixosModules.home-manager` from the brutus module list in `modules/flake/nixos/default.nix`.
- Remove the now-empty `hosts/brutus/home-manager/**` tree and its import from `hosts/brutus/default.nix`.
- Delete the `home-manager.users.jasonbk.programs.*.enable = mkForce false` block from `hosts/brutus/my.nix` (nothing left to override once HM is gone).

`system.stateVersion` already lives in `hosts/brutus/configuration.nix`, so the dropped `home.stateVersion` needs no replacement.

## Verify
- `nix eval .#nixosConfigurations.brutus.config.system.build.toplevel` — evaluates clean.
- `nix flake check` — passes (exit 0), including `brutus-matrix`, `brutus-matrix-rtc`, `brutus-ntfy`, `ssh-agent-switcher`, and the `my-*` wrapper checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)